### PR TITLE
Feat/extend step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 8.2.0 - Extended `step()` function by additional options
+
+* Extended `step(data, options)` function passed to aggregator by `options` parameter:
+  * `options.message` - replaces the step message on call.
+  * `options.suppress` - suppresses the call of the `progress()` function while still counting the steps.
+
 ## 8.1.0 - Added functionality to trim images
 
 * Added a `trim` option to `modifyImages`. If set to `true`, it will trim pixels from all edges that contain values similar to the color of the top-left pixel. Default is `false`.

--- a/README.md
+++ b/README.md
@@ -39,12 +39,19 @@ export default function start(step, progress, options) {
 
 #### `start({ aggregatorFile, progress, timeoutToResendStatus[, ...other options] })`
 
-* `aggregatorFile` (`string`, required) is the file that should be spawn into a process. It consists of an exported 
-  default function `start(step, progress[, options])`, which will be called with these parameters: `step` is a function 
-  for promise chains that will count the current steps and sends a debug message as soon as the aggregator runs over 
-  this step. The `progress` function is used for longer running "inner" processes, like minification of images. This 
-  function can be passed to some of the helper functions used in the promise chains. `options` is a JSON object that was
-   passed to the `start` function. This can be used to provide variables from the outer process to the forked one. 
+* `aggregatorFile` (`string`, required) is the file that should be spawn into a process. It consists of an exported
+  default function `start(step, progress[, options])`, which will be called with these parameters:
+  * `step` - the factory function for promise chains that will count the current steps and sends a debug message as
+    soon as the aggregator runs over this step. The factory returns a function which can be called with following
+    parameters:
+    * `data: any` - the data which will be passed through within the chain.
+    * `options?: {message: string, suppress: boolean}` - additional options: `message` replaces the original message to
+      be sent to progress function; `suppress` flag prevents the progress function to be called (while still counting
+      the steps).
+  * `progress` - the function is used for longer running "inner" processes, like minification of images. This
+    function can be passed to some of the helper functions used in the promise chains.
+  * `options` - a JSON object that was passed to the `start` function. This can be used to provide variables from the
+    outer process to the forked one.
 * `progress` is a function that will be called with an object three properties:
   * `steps` - the number of all counted steps. 
   * `currentStep` - the current step. Use `steps` and `currentStep` to calculate the percentage of your progress.

--- a/lib/__tests__/aggregatorDummyWithReplacedAndHiddenMessages.js
+++ b/lib/__tests__/aggregatorDummyWithReplacedAndHiddenMessages.js
@@ -1,0 +1,24 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = start;
+
+function start(step) {
+  var stepA = step("step A");
+  var stepB = step("step B");
+  var stepC = step("step C");
+  var stepD = step("step D");
+  return Promise.resolve().then(stepA).then(function (data) {
+    return stepB(data, {
+      message: "step B - REPLACED!"
+    });
+  }).then(function (data) {
+    return stepC(data, {
+      suppress: true
+    });
+  }).then(stepD);
+}
+
+module.exports = exports.default;

--- a/lib/attachments/imageResizer.js
+++ b/lib/attachments/imageResizer.js
@@ -11,57 +11,34 @@ var _sharp = _interopRequireDefault(require("sharp"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } return target; }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
 function generateThumb(options) {
-  var fromPath = options.fromPath,
-      toPath = options.toPath,
-      imageHeight = options.imageHeight,
-      imageWidth = options.imageWidth,
-      _options$minify = options.minify,
-      minify = _options$minify === void 0 ? false : _options$minify,
-      _options$trim = options.trim,
-      trim = _options$trim === void 0 ? false : _options$trim;
-  return getTransformer({
-    fromPath: fromPath,
-    resize: true,
-    imageHeight: imageHeight,
-    imageWidth: imageWidth,
-    minify: minify,
-    trim: trim
-  }).then(function (sharpObj) {
-    return sharpObj.toFile(toPath);
-  });
+  return modifyImage(_objectSpread({}, options, {
+    resize: true
+  }));
 }
 
 function reduceImage(options) {
-  var fromPath = options.fromPath,
-      toPath = options.toPath,
-      _options$trim2 = options.trim,
-      trim = _options$trim2 === void 0 ? false : _options$trim2;
-  return getTransformer({
-    fromPath: fromPath,
+  return modifyImage(_objectSpread({}, options, {
     resize: false,
-    minify: true,
-    trim: trim
-  }).then(function (sharpObj) {
-    return sharpObj.toFile(toPath);
-  });
+    minify: true
+  }));
 }
 
 function trimImage(options) {
-  var fromPath = options.fromPath,
-      toPath = options.toPath;
-  return getTransformer({
-    fromPath: fromPath,
+  return modifyImage(_objectSpread({}, options, {
     resize: false,
     minify: false,
     trim: true
-  }).then(function (sharpObj) {
-    return sharpObj.toFile(toPath);
-  });
+  }));
 }
 
-function getTransformer(_ref) {
+function modifyImage(_ref) {
   var fromPath = _ref.fromPath,
+      toPath = _ref.toPath,
       resize = _ref.resize,
       imageHeight = _ref.imageHeight,
       imageWidth = _ref.imageWidth,
@@ -103,5 +80,7 @@ function getTransformer(_ref) {
     } catch (err) {
       reject(err);
     }
+  }).then(function (sharpObj) {
+    return sharpObj.toFile(toPath);
   });
 }

--- a/lib/forker.js
+++ b/lib/forker.js
@@ -87,15 +87,23 @@ function run(aggregatorFile, options) {
   function step(message) {
     allSteps = allSteps + 1;
     return function (data) {
+      var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+      var newMessage = options.message,
+          _options$suppress = options.suppress,
+          suppress = _options$suppress === void 0 ? false : _options$suppress;
       lastStep = lastStep + 1;
-      process.send({
-        action: "PROGRESS",
-        payload: {
-          message: message,
-          currentStep: lastStep,
-          steps: allSteps
-        }
-      });
+
+      if (!suppress) {
+        process.send({
+          action: "PROGRESS",
+          payload: {
+            message: newMessage || message,
+            currentStep: lastStep,
+            steps: allSteps
+          }
+        });
+      }
+
       return data;
     };
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tableaux-aggregator",
-  "version": "8.1.0",
+  "version": "8.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tableaux-aggregator",
-  "version": "8.1.0",
+  "version": "8.2.0",
   "description": "Core aggregator functions",
   "main": "lib/index.js",
   "files": [

--- a/src/__tests__/aggregatorDummyWithReplacedAndHiddenMessages.js
+++ b/src/__tests__/aggregatorDummyWithReplacedAndHiddenMessages.js
@@ -1,0 +1,13 @@
+export default function start(step) {
+  const stepA = step("step A");
+  const stepB = step("step B");
+  const stepC = step("step C");
+  const stepD = step("step D");
+
+  return Promise
+    .resolve()
+    .then(stepA)
+    .then(data => stepB(data, { message: "step B - REPLACED!" }))
+    .then(data => stepC(data, { suppress: true }))
+    .then(stepD);
+}

--- a/src/aggregationProcess.spec.js
+++ b/src/aggregationProcess.spec.js
@@ -8,6 +8,7 @@ describe("aggregation-process", function () {
 
   const aggregatorBreaking = `${__dirname}/__tests__/aggregatorBreaking.js`;
   const aggregatorDummy = `${__dirname}/__tests__/aggregatorDummy.js`;
+  const aggregatorDummyWithReplacedAndHiddenMessages = `${__dirname}/__tests__/aggregatorDummyWithReplacedAndHiddenMessages.js`;
   const aggregatorFile = `${__dirname}/__tests__/aggregatorWorking.js`;
   const aggregatorFileSubsteps = `${__dirname}/__tests__/aggregatorSubsteps.js`;
   const aggregatorFileSubsteps2 = `${__dirname}/__tests__/aggregatorSubsteps2.js`;
@@ -70,6 +71,29 @@ describe("aggregation-process", function () {
         lastStep = currentStep;
         expect(currentStep).to.be.at.most(steps);
         expect(steps).to.be(numberOfSteps);
+      }
+    }).then(() => {
+      expect(lastStep).to.be(numberOfSteps);
+    });
+  });
+
+  it("can replace or hide message in step", () => {
+    const messages = ["Starting aggregator", "step A", "step B - REPLACED!", "step C", "step D", "Done"];
+    const suppressedMessages = ["step C"];
+    const numberOfSteps = messages.length - 1;
+
+    let lastStep = -1;
+
+    return start({
+      aggregatorFile: aggregatorDummyWithReplacedAndHiddenMessages,
+      progress: ({message, currentStep, steps}) => {
+        expect(message).to.startWith(messages[currentStep]);
+        expect(suppressedMessages.indexOf(message)).to.be(-1);
+        expect(lastStep).to.be.lt(currentStep);
+        expect(currentStep).to.be.at.most(steps);
+        expect(steps).to.be(numberOfSteps);
+
+        lastStep = currentStep;
       }
     }).then(() => {
       expect(lastStep).to.be(numberOfSteps);

--- a/src/forker.js
+++ b/src/forker.js
@@ -90,18 +90,21 @@ function run(aggregatorFile, options) {
     allSteps = allSteps + 1;
 
     return (data, options = {}) => {
-      const {message: newMessage} = options;
+      const {message: newMessage, suppress = false} = options;
 
       lastStep = lastStep + 1;
 
-      process.send({
-        action: "PROGRESS",
-        payload: {
-          message: newMessage || message,
-          currentStep: lastStep,
-          steps: allSteps
-        }
-      });
+      if (!suppress) {
+        process.send({
+          action: "PROGRESS",
+          payload: {
+            message: newMessage || message,
+            currentStep: lastStep,
+            steps: allSteps
+          }
+        });
+      }
+
       return data;
     };
   }

--- a/src/forker.js
+++ b/src/forker.js
@@ -89,12 +89,15 @@ function run(aggregatorFile, options) {
   function step(message) {
     allSteps = allSteps + 1;
 
-    return data => {
+    return (data, options = {}) => {
+      const {message: newMessage} = options;
+
       lastStep = lastStep + 1;
+
       process.send({
         action: "PROGRESS",
         payload: {
-          message: message,
+          message: newMessage || message,
           currentStep: lastStep,
           steps: allSteps
         }


### PR DESCRIPTION
Erweiterung für die `step()` Funktion um den `options` Parameter, um die Nachricht beim eigentlich Aufruf zu ersetzen oder die Meldung über `progress()` komplett zu unterdrücken.