### PR TITLE
Feat/include columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 8.3.0 - Extended `getEntitiesOfTable()` function by `includeColumns` option
+
+* `includeColumns: String[]` option has been added for `getEntitiesOfTable()`. Specified as an array of strings, it
+  defines columns that will be followed on the top level.
+
 ## 8.2.0 - Extended `step()` function by additional options
 
 * Extended `step(data, options)` function passed to aggregator by `options` parameter:

--- a/README.md
+++ b/README.md
@@ -67,10 +67,14 @@ export default function start(step, progress, options) {
 
 * `tableName` is the entry point for downloading all entities that are (recursively) linked.
 * `options` is an object consisting of the following options:
-  * `pimUrl`, `String` (required) - The URL pointing to the GRUD instance.
-  * `disableFollow`, `Array[String]` (optional) - Defaults to empty array. An array of column names that will not be 
-    followed.
-  * `maxEntriesPerRequest`, `Integer` (optional) - Defaults to 500. An integer greater than 0 to limit the amount of 
+  * `pimUrl: String` (required) - The URL pointing to the GRUD instance.
+  * `disableFollow: String[][]` (optional) - Defaults to empty array. An array of nested column lists that will not be 
+    followed, i.e. `[["topLevelLinkColumn", "secondLevelLinkColumn"], ["anotherTopLevelLinkColumn]]`.
+  * `includeColumns: String[]` (optional) - If specified, defines a list of columns on the top level that will be
+    followed. This option can be combined with `disableFollow` option which may override the former. For example, if
+    there is a column `"foo"` within the `includeColumns` array, and there is an entry `["foo"]`
+    within `disableFollow`, then the column `"foo"` will not be followed.
+  * `maxEntriesPerRequest: number` (optional) - Defaults to 500. An integer greater than 0 to limit the amount of 
     work on each request done by the Grud instance. Higher values make less requests but may run into timeouts if the 
     Grud instance is not able to handle as much data.
   * `headers`, `Object` (optional) - Defaults to {}. An object with key values pairs for http headers to set on every request.

--- a/lib/entities.js
+++ b/lib/entities.js
@@ -15,6 +15,7 @@ function getEntitiesOfTable(tableName) {
   var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
   var _options$disableFollo = options.disableFollow,
       disableFollow = _options$disableFollo === void 0 ? [] : _options$disableFollo,
+      includeColumns = options.includeColumns,
       pimUrl = options.pimUrl,
       _options$maxEntriesPe = options.maxEntriesPerRequest,
       maxEntriesPerRequest = _options$maxEntriesPe === void 0 ? 500 : _options$maxEntriesPe,
@@ -32,7 +33,13 @@ function getEntitiesOfTable(tableName) {
   if (!_lodash.default.isArray(disableFollow) || _lodash.default.some(disableFollow, function (columns) {
     return !_lodash.default.isArray(columns);
   })) {
-    throw new Error("Expecting an array of columns as disableFollow");
+    throw new Error("Expecting an array of column lists as disableFollow");
+  }
+
+  if (includeColumns && (!_lodash.default.isArray(includeColumns) || _lodash.default.some(includeColumns, function (column) {
+    return !_lodash.default.isString(column);
+  }))) {
+    throw new Error("Expecting an array of columns as includeColumns");
   }
 
   if (!_lodash.default.isInteger(maxEntriesPerRequest) || maxEntriesPerRequest <= 0) {
@@ -52,33 +59,37 @@ function getEntitiesOfTable(tableName) {
     headers: headers
   }, tableName).then(function (tablesFromPim) {
     return Promise.all(_lodash.default.map(tablesFromPim, function (table) {
-      return getTableAndLinkedTablesAsPromise(table.id, disableFollow, maxEntriesPerRequest);
+      return getTableAndLinkedTablesAsPromise(table.id, disableFollow, maxEntriesPerRequest, includeColumns);
     }));
   }).then(function () {
     return mapRowsOfTables(tables);
   });
 
-  function getTableAndLinkedTablesAsPromise(tableId, disableFollow, maxEntriesPerRequest) {
+  function getTableAndLinkedTablesAsPromise(tableId, disableFollow, maxEntriesPerRequest, includeColumns) {
     if (!promises[tableId]) {
       var promiseOfLinkedTables = (0, _pimApi.getCompleteTable)({
         pimUrl: pimUrl,
         headers: headers
       }, tableId, maxEntriesPerRequest).then(function (table) {
         tables[tableId] = table;
-        return Promise.all(_lodash.default.flatMap(table.columns, function (column) {
-          if (!promises[column.toTable] && column.kind === "link" && !isDisabled(column.name, disableFollow)) {
-            var filteredDisableFollow = _lodash.default.filter(disableFollow, function (columns) {
-              return !_lodash.default.isEmpty(columns) && _lodash.default.head(columns) === column.name;
-            });
 
-            var nextDisableFollow = _lodash.default.map(filteredDisableFollow, function (columns) {
-              return _lodash.default.tail(columns);
-            });
+        var columnsToFollow = _lodash.default.filter(table.columns, function (_ref) {
+          var kind = _ref.kind,
+              name = _ref.name,
+              toTable = _ref.toTable;
+          return !promises[toTable] && kind === "link" && !isColumnDisabled(name, disableFollow) && isColumnIncluded(name, includeColumns);
+        });
 
-            return [getTableAndLinkedTablesAsPromise(column.toTable, nextDisableFollow, maxEntriesPerRequest)];
-          } else {
-            return [];
-          }
+        return Promise.all(_lodash.default.map(columnsToFollow, function (column) {
+          var filteredDisableFollow = _lodash.default.filter(disableFollow, function (columns) {
+            return !_lodash.default.isEmpty(columns) && _lodash.default.head(columns) === column.name;
+          });
+
+          var nextDisableFollow = _lodash.default.map(filteredDisableFollow, function (columns) {
+            return _lodash.default.tail(columns);
+          });
+
+          return getTableAndLinkedTablesAsPromise(column.toTable, nextDisableFollow, maxEntriesPerRequest);
         }));
       });
       promises[tableId] = promiseOfLinkedTables;
@@ -88,14 +99,16 @@ function getEntitiesOfTable(tableName) {
     }
   }
 
-  function isDisabled(columnName, disableFollow) {
-    var disabledFollowInTable = _lodash.default.filter(disableFollow, function (columns) {
-      return _lodash.default.size(columns) === 1;
-    });
+  function isColumnIncluded(columnName, includeColumns) {
+    return _lodash.default.isNil(includeColumns) || _lodash.default.isArray(includeColumns) && includeColumns.includes(columnName);
+  }
 
-    return _lodash.default.some(disabledFollowInTable, function (columns) {
-      return _lodash.default.head(columns) === columnName;
-    });
+  function isColumnDisabled(columnName, disableFollow) {
+    var disabledColumns = _lodash.default.filter(disableFollow, function (columns) {
+      return _lodash.default.size(columns) === 1;
+    }).flat();
+
+    return disabledColumns.includes(columnName);
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tableaux-aggregator",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tableaux-aggregator",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "description": "Core aggregator functions",
   "main": "lib/index.js",
   "files": [

--- a/src/__tests__/testTableIncludeColumns1.json
+++ b/src/__tests__/testTableIncludeColumns1.json
@@ -1,0 +1,285 @@
+{
+  "1": {
+    "id": 1,
+    "name": "testTable",
+    "displayName": {
+      "de": "Test Tabelle",
+      "en": "Test table"
+    },
+    "description": {
+      "de": "Eine Tabelle zum Testen",
+      "en": "A table to test"
+    },
+    "columns": [
+      {
+        "id": 1,
+        "name": "slShorttext",
+        "kind": "shorttext",
+        "identifier": true,
+        "multilanguage": false,
+        "displayName": {
+          "de": "Irgendein Text",
+          "en": "Some text"
+        },
+        "description": {
+          "de": "Eine Beschreibung der einfachen Textspalte",
+          "en": "A description of the simple text column"
+        }
+      },
+      {
+        "id": 2,
+        "name": "mlShorttext",
+        "kind": "shorttext",
+        "multilanguage": true,
+        "languageType": "language",
+        "displayName": {
+          "de": "Irgendein mehrsprachiger Text",
+          "en": "Some multilanguage text"
+        },
+        "description": {
+          "de": "Eine Beschreibung der mehrsprachigen Textspalte",
+          "en": "A description of the multilanguage text column"
+        }
+      },
+      {
+        "id": 3,
+        "name": "slAttachment",
+        "kind": "attachment",
+        "multilanguage": false,
+        "displayName": {
+          "de": "Irgendein sprachneutrales Attachment",
+          "en": "Some language neutral attachment"
+        },
+        "description": {
+          "de": "Eine Beschreibung der sprachneutralen Attachmentspalte",
+          "en": "A description of the language neutral attachment column"
+        }
+      },
+      {
+        "id": 4,
+        "name": "someLink",
+        "kind": "link",
+        "multilanguage": false,
+        "displayName": {
+          "de": "Irgendein Link",
+          "en": "Some link"
+        },
+        "description": {
+          "de": "Eine Beschreibung der Linkspalte",
+          "en": "A description of the link column"
+        },
+        "toTable": 3,
+        "toColumn": {
+          "id": 0,
+          "ordering": 0,
+          "name": "ID",
+          "kind": "concat",
+          "multilanguage": false,
+          "identifier": true,
+          "displayName": {},
+          "description": {},
+          "concats": [
+            {
+              "id": 1,
+              "name": "anotherLink",
+              "kind": "link",
+              "identifier": true,
+              "multilanguage": false,
+              "displayName": {
+                "de": "Ein weiterer Link",
+                "en": "Some other link"
+              },
+              "description": {
+                "de": "Eine Beschreibung dieser Linkspalte",
+                "en": "A description of this link column"
+              },
+              "toTable": 2,
+              "toColumn": {
+                "id": 1,
+                "name": "testColumn",
+                "kind": "shorttext",
+                "identifier": true,
+                "multilanguage": false,
+                "displayName": {
+                  "en": "Some other text"
+                },
+                "description": {
+                  "en": "A description of the simple text column in table 2"
+                }
+              }
+            },
+            {
+              "id": 2,
+              "name": "identifier",
+              "kind": "shorttext",
+              "identifier": true,
+              "multilanguage": false,
+              "displayName": {
+                "de": "Identifizierungsspalte",
+                "en": "Identification column"
+              },
+              "description": {}
+            }
+          ]
+        }
+      }
+    ],
+    "rows": {
+      "1": {
+        "id": 1,
+        "values": [
+          "something1 links to 1",
+          {
+            "de": "Hallo",
+            "en": "Hello"
+          },
+          [
+            {
+              "title": {
+                "de": "Titel des ersten Attachments",
+                "en": "Title of first attachment"
+              },
+              "description": {
+                "de": "Beschreibung des ersten Attachments",
+                "en": "Description of first attachment"
+              },
+              "externalName": {
+                "de": "externer-name.txt",
+                "en": "external-name.png"
+              },
+              "internalName": {
+                "de": "66845e6e-f186-4fa1-9540-0c6e9b1c4cfb.txt",
+                "en": "fd0488b2-4b59-474c-80af-461b379b0ce3.png"
+              },
+              "mimeType": {
+                "de": "text/plain",
+                "en": "image/png"
+              },
+              "url": {
+                "de": "/files/b1446686-bcec-4a6e-a2b5-54b209167499/de/externer-name.txt",
+                "en": "/files/66035e76-ee68-48af-8cdd-d46a3cb63de4/en/external-name.png"
+              }
+            },
+            {
+              "title": {
+                "de": "Titel des zweiten Attachments",
+                "en": "Title of second attachment"
+              },
+              "description": {
+                "en": "Description of second attachment"
+              },
+              "externalName": {
+                "de": "irgendeine-datei.txt",
+                "en": "some-file.txt"
+              },
+              "internalName": {
+                "en": "588a91d7-f526-4849-88b2-7ab20195038d.txt"
+              },
+              "mimeType": {
+                "en": "text/plain"
+              },
+              "url": {
+                "en": "/files/8a2bed0e-fb6e-42bb-a3fd-ec9da2bdd9a6/en/some-file.txt"
+              }
+            }
+          ],
+          [
+            {
+              "id": 1,
+              "value": [
+                [
+                  {
+                    "id": 1,
+                    "value": [
+                      "some other thing"
+                    ]
+                  }
+                ],
+                "my identifying text, linking to row 1 in anotherTestTable"
+              ]
+            }
+          ]
+        ]
+      },
+      "2": {
+        "id": 2,
+        "values": [
+          "something2 links to 3 and 4",
+          {
+            "de": "Hallo2",
+            "en": "Hello2"
+          },
+          [],
+          [
+            {
+              "id": 3,
+              "value": [
+                [
+                  {
+                    "id": 1,
+                    "value": [
+                      "some other thing"
+                    ]
+                  },
+                  {
+                    "id": 2,
+                    "value": [
+                      "some other thing in second row"
+                    ]
+                  }
+                ],
+                "my third row identifying text, linking to both rows in anotherTestTable"
+              ]
+            },
+            {
+              "id": 4,
+              "value": [
+                [],
+                "my fourth row identifying text, linking to no rows in anotherTestTable"
+              ]
+            }
+          ]
+        ]
+      },
+      "3": {
+        "id": 3,
+        "values": [
+          "something3 links to none",
+          {
+            "de": "Hallo3",
+            "en": "Hello3"
+          },
+          [],
+          []
+        ]
+      },
+      "4": {
+        "id": 4,
+        "values": [
+          "something4 links to second row",
+          {
+            "de": "Hallo3",
+            "en": "Hello3"
+          },
+          [],
+          [
+            {
+              "id": 2,
+              "value": [
+                [
+                  {
+                    "id": 2,
+                    "value": [
+                      "some other thing in second row"
+                    ]
+                  }
+                ],
+                "my second row identifying text, linking to row 2 in anotherTestTable"
+              ]
+            }
+          ]
+        ]
+      }
+    }
+  }
+}

--- a/src/__tests__/testTableIncludeColumns2.json
+++ b/src/__tests__/testTableIncludeColumns2.json
@@ -1,0 +1,609 @@
+{
+  "1": {
+    "id": 1,
+    "name": "testTable",
+    "displayName": {
+      "de": "Test Tabelle",
+      "en": "Test table"
+    },
+    "description": {
+      "de": "Eine Tabelle zum Testen",
+      "en": "A table to test"
+    },
+    "columns": [
+      {
+        "id": 1,
+        "name": "slShorttext",
+        "kind": "shorttext",
+        "identifier": true,
+        "multilanguage": false,
+        "displayName": {
+          "de": "Irgendein Text",
+          "en": "Some text"
+        },
+        "description": {
+          "de": "Eine Beschreibung der einfachen Textspalte",
+          "en": "A description of the simple text column"
+        }
+      },
+      {
+        "id": 2,
+        "name": "mlShorttext",
+        "kind": "shorttext",
+        "multilanguage": true,
+        "languageType": "language",
+        "displayName": {
+          "de": "Irgendein mehrsprachiger Text",
+          "en": "Some multilanguage text"
+        },
+        "description": {
+          "de": "Eine Beschreibung der mehrsprachigen Textspalte",
+          "en": "A description of the multilanguage text column"
+        }
+      },
+      {
+        "id": 3,
+        "name": "slAttachment",
+        "kind": "attachment",
+        "multilanguage": false,
+        "displayName": {
+          "de": "Irgendein sprachneutrales Attachment",
+          "en": "Some language neutral attachment"
+        },
+        "description": {
+          "de": "Eine Beschreibung der sprachneutralen Attachmentspalte",
+          "en": "A description of the language neutral attachment column"
+        }
+      },
+      {
+        "id": 4,
+        "name": "someLink",
+        "kind": "link",
+        "multilanguage": false,
+        "displayName": {
+          "de": "Irgendein Link",
+          "en": "Some link"
+        },
+        "description": {
+          "de": "Eine Beschreibung der Linkspalte",
+          "en": "A description of the link column"
+        },
+        "toTable": 3,
+        "toColumn": {
+          "id": 0,
+          "ordering": 0,
+          "name": "ID",
+          "kind": "concat",
+          "multilanguage": false,
+          "identifier": true,
+          "displayName": {},
+          "description": {},
+          "concats": [
+            {
+              "id": 1,
+              "name": "anotherLink",
+              "kind": "link",
+              "identifier": true,
+              "multilanguage": false,
+              "displayName": {
+                "de": "Ein weiterer Link",
+                "en": "Some other link"
+              },
+              "description": {
+                "de": "Eine Beschreibung dieser Linkspalte",
+                "en": "A description of this link column"
+              },
+              "toTable": 2,
+              "toColumn": {
+                "id": 1,
+                "name": "testColumn",
+                "kind": "shorttext",
+                "identifier": true,
+                "multilanguage": false,
+                "displayName": {
+                  "en": "Some other text"
+                },
+                "description": {
+                  "en": "A description of the simple text column in table 2"
+                }
+              }
+            },
+            {
+              "id": 2,
+              "name": "identifier",
+              "kind": "shorttext",
+              "identifier": true,
+              "multilanguage": false,
+              "displayName": {
+                "de": "Identifizierungsspalte",
+                "en": "Identification column"
+              },
+              "description": {}
+            }
+          ]
+        }
+      }
+    ],
+    "rows": {
+      "1": {
+        "id": 1,
+        "values": [
+          "something1 links to 1",
+          {
+            "de": "Hallo",
+            "en": "Hello"
+          },
+          [
+            {
+              "title": {
+                "de": "Titel des ersten Attachments",
+                "en": "Title of first attachment"
+              },
+              "description": {
+                "de": "Beschreibung des ersten Attachments",
+                "en": "Description of first attachment"
+              },
+              "externalName": {
+                "de": "externer-name.txt",
+                "en": "external-name.png"
+              },
+              "internalName": {
+                "de": "66845e6e-f186-4fa1-9540-0c6e9b1c4cfb.txt",
+                "en": "fd0488b2-4b59-474c-80af-461b379b0ce3.png"
+              },
+              "mimeType": {
+                "de": "text/plain",
+                "en": "image/png"
+              },
+              "url": {
+                "de": "/files/b1446686-bcec-4a6e-a2b5-54b209167499/de/externer-name.txt",
+                "en": "/files/66035e76-ee68-48af-8cdd-d46a3cb63de4/en/external-name.png"
+              }
+            },
+            {
+              "title": {
+                "de": "Titel des zweiten Attachments",
+                "en": "Title of second attachment"
+              },
+              "description": {
+                "en": "Description of second attachment"
+              },
+              "externalName": {
+                "de": "irgendeine-datei.txt",
+                "en": "some-file.txt"
+              },
+              "internalName": {
+                "en": "588a91d7-f526-4849-88b2-7ab20195038d.txt"
+              },
+              "mimeType": {
+                "en": "text/plain"
+              },
+              "url": {
+                "en": "/files/8a2bed0e-fb6e-42bb-a3fd-ec9da2bdd9a6/en/some-file.txt"
+              }
+            }
+          ],
+          [
+            {
+              "id": 1,
+              "value": [
+                [
+                  {
+                    "id": 1,
+                    "value": [
+                      "some other thing"
+                    ]
+                  }
+                ],
+                "my identifying text, linking to row 1 in anotherTestTable"
+              ]
+            }
+          ]
+        ]
+      },
+      "2": {
+        "id": 2,
+        "values": [
+          "something2 links to 3 and 4",
+          {
+            "de": "Hallo2",
+            "en": "Hello2"
+          },
+          [],
+          [
+            {
+              "id": 3,
+              "value": [
+                [
+                  {
+                    "id": 1,
+                    "value": [
+                      "some other thing"
+                    ]
+                  },
+                  {
+                    "id": 2,
+                    "value": [
+                      "some other thing in second row"
+                    ]
+                  }
+                ],
+                "my third row identifying text, linking to both rows in anotherTestTable"
+              ]
+            },
+            {
+              "id": 4,
+              "value": [
+                [],
+                "my fourth row identifying text, linking to no rows in anotherTestTable"
+              ]
+            }
+          ]
+        ]
+      },
+      "3": {
+        "id": 3,
+        "values": [
+          "something3 links to none",
+          {
+            "de": "Hallo3",
+            "en": "Hello3"
+          },
+          [],
+          []
+        ]
+      },
+      "4": {
+        "id": 4,
+        "values": [
+          "something4 links to second row",
+          {
+            "de": "Hallo3",
+            "en": "Hello3"
+          },
+          [],
+          [
+            {
+              "id": 2,
+              "value": [
+                [
+                  {
+                    "id": 2,
+                    "value": [
+                      "some other thing in second row"
+                    ]
+                  }
+                ],
+                "my second row identifying text, linking to row 2 in anotherTestTable"
+              ]
+            }
+          ]
+        ]
+      }
+    }
+  },
+  "2": {
+    "id": 2,
+    "name": "anotherTestTable",
+    "displayName": {
+      "en": "Test table 2"
+    },
+    "description": {
+      "en": "Another table to test"
+    },
+    "columns": [
+      {
+        "id": 1,
+        "name": "testColumn",
+        "kind": "shorttext",
+        "identifier": true,
+        "multilanguage": false,
+        "displayName": {
+          "en": "Some other text"
+        },
+        "description": {
+          "en": "A description of the simple text column in table 2"
+        }
+      },
+      {
+        "id": 2,
+        "name": "otherColumn",
+        "kind": "shorttext",
+        "identifier": false,
+        "multilanguage": true,
+        "languageType": "language",
+        "displayName": {
+          "en": "Some other multilanguage text"
+        },
+        "description": {
+          "en": "A description of the multilanguage text column in table 2"
+        }
+      }
+    ],
+    "rows": {
+      "1": {
+        "id": 1,
+        "values": [
+          "some other thing",
+          {
+            "en": "Welcome"
+          }
+        ]
+      },
+      "2": {
+        "id": 2,
+        "values": [
+          "some other thing in second row",
+          {
+            "en": "Good day"
+          }
+        ]
+      },
+      "3": {
+        "id": 3,
+        "values": [
+          "a third item that is never linked",
+          {
+            "en": "Hello"
+          }
+        ]
+      }
+    }
+  },
+  "3": {
+    "id": 3,
+    "name": "thirdTestTable",
+    "langtags": [
+      "de",
+      "en"
+    ],
+    "displayName": {
+      "de": "Test Tabelle 3",
+      "en": "Test table 3"
+    },
+    "description": {
+      "de": "Eine dritte Tabelle zum Testen",
+      "en": "A third table to test"
+    },
+    "columns": [
+      {
+        "id": 0,
+        "ordering": 0,
+        "name": "ID",
+        "kind": "concat",
+        "multilanguage": false,
+        "identifier": true,
+        "displayName": {},
+        "description": {},
+        "concats": [
+          {
+            "id": 1,
+            "name": "anotherLink",
+            "kind": "link",
+            "identifier": true,
+            "multilanguage": false,
+            "displayName": {
+              "de": "Ein weiterer Link",
+              "en": "Some other link"
+            },
+            "description": {
+              "de": "Eine Beschreibung dieser Linkspalte",
+              "en": "A description of this link column"
+            },
+            "toTable": 2,
+            "toColumn": {
+              "id": 1,
+              "name": "testColumn",
+              "kind": "shorttext",
+              "identifier": true,
+              "multilanguage": false,
+              "displayName": {
+                "en": "Some other text"
+              },
+              "description": {
+                "en": "A description of the simple text column in table 2"
+              }
+            }
+          },
+          {
+            "id": 2,
+            "name": "identifier",
+            "kind": "shorttext",
+            "identifier": true,
+            "multilanguage": false,
+            "displayName": {
+              "de": "Identifizierungsspalte",
+              "en": "Identification column"
+            },
+            "description": {}
+          }
+        ]
+      },
+      {
+        "id": 1,
+        "name": "anotherLink",
+        "kind": "link",
+        "identifier": true,
+        "multilanguage": false,
+        "displayName": {
+          "de": "Ein weiterer Link",
+          "en": "Some other link"
+        },
+        "description": {
+          "de": "Eine Beschreibung dieser Linkspalte",
+          "en": "A description of this link column"
+        },
+        "toTable": 2,
+        "toColumn": {
+          "id": 1,
+          "name": "testColumn",
+          "kind": "shorttext",
+          "identifier": true,
+          "multilanguage": false,
+          "displayName": {
+            "en": "Some other text"
+          },
+          "description": {
+            "en": "A description of the simple text column in table 2"
+          }
+        }
+      },
+      {
+        "id": 2,
+        "name": "identifier",
+        "kind": "shorttext",
+        "identifier": true,
+        "multilanguage": false,
+        "displayName": {
+          "de": "Identifizierungsspalte",
+          "en": "Identification column"
+        },
+        "description": {}
+      },
+      {
+        "id": 3,
+        "name": "someNumber",
+        "kind": "number",
+        "identifier": false,
+        "multilanguage": true,
+        "languageType": "country",
+        "displayName": {
+          "de": "Irgendeine Zahl",
+          "en": "Some number"
+        },
+        "description": {}
+      }
+    ],
+    "rows": {
+      "1": {
+        "id": 1,
+        "values": [
+          [
+            [
+              {
+                "id": 1,
+                "value": [
+                  "some other thing"
+                ]
+              }
+            ],
+            "my identifying text, linking to row 1 in anotherTestTable"
+          ],
+          [
+            {
+              "id": 1,
+              "value": [
+                "some other thing"
+              ]
+            }
+          ],
+          "my identifying text, linking to row 1 in anotherTestTable",
+          {
+            "de": "11",
+            "en": "12"
+          }
+        ]
+      },
+      "2": {
+        "id": 2,
+        "values": [
+          [
+            [
+              {
+                "id": 2,
+                "value": [
+                  "some other thing in second row"
+                ]
+              }
+            ],
+            "my second row identifying text, linking to row 2 in anotherTestTable"
+          ],
+          [
+            {
+              "id": 2,
+              "value": [
+                "some other thing in second row"
+              ]
+            }
+          ],
+          "my second row identifying text, linking to row 2 in anotherTestTable",
+          {
+            "de": "21",
+            "en": "22"
+          }
+        ]
+      },
+      "3": {
+        "id": 3,
+        "values": [
+          [
+            [
+              {
+                "id": 1,
+                "value": [
+                  "some other thing"
+                ]
+              },
+              {
+                "id": 2,
+                "value": [
+                  "some other thing in second row"
+                ]
+              }
+            ],
+            "my third row identifying text, linking to both rows in anotherTestTable"
+          ],
+          [
+            {
+              "id": 1,
+              "value": [
+                "some other thing"
+              ]
+            },
+            {
+              "id": 2,
+              "value": [
+                "some other thing in second row"
+              ]
+            }
+          ],
+          "my third row identifying text, linking to both rows in anotherTestTable",
+          {
+            "de": "31",
+            "en": "32"
+          }
+        ]
+      },
+      "4": {
+        "id": 4,
+        "values": [
+          [
+            [],
+            "my fourth row identifying text, linking to no rows in anotherTestTable"
+          ],
+          [],
+          "my fourth row identifying text, linking to no rows in anotherTestTable",
+          {
+            "de": "41",
+            "en": "42"
+          }
+        ]
+      },
+      "5": {
+        "id": 5,
+        "values": [
+          [
+            [],
+            "my fifth row identifying text, linking to no rows in anotherTestTable and not gets linked"
+          ],
+          [],
+          "my fifth row identifying text, linking to no rows in anotherTestTable and not gets linked",
+          {
+            "de": "51",
+            "en": "52"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/entities.spec.js
+++ b/src/entities.spec.js
@@ -3,6 +3,8 @@ import express from "express";
 import {getEntitiesOfTable} from "./entities";
 import disableFollowTestTableOnly from "./__tests__/testTableDisableFollow1.json";
 import disableFollowTestTableAndThirdTableOnly from "./__tests__/testTableDisableFollow2.json";
+import includeColumnsTestTableOnly from "./__tests__/testTableIncludeColumns1.json";
+import includeColumnsAllTables from "./__tests__/testTableIncludeColumns2.json";
 
 describe("getEntitiesOfTable", () => {
 
@@ -171,12 +173,11 @@ describe("getEntitiesOfTable", () => {
   });
 
   describe("setting disableFollow", () => {
-
     it("requires an array", () => {
       expect(() => getEntitiesOfTable("testTable", {
         pimUrl: SERVER_URL,
         disableFollow: true
-      })).to.throw(/array of columns/i);
+      })).to.throw(/array of column lists/i);
     });
 
     it("requires an array of arrays", () => {
@@ -185,7 +186,7 @@ describe("getEntitiesOfTable", () => {
         disableFollow: [
           "abc", 2, true
         ]
-      })).to.throw(/array of columns/i);
+      })).to.throw(/array of column lists/i);
     });
 
     it("should not download the specified links", () => {
@@ -209,7 +210,52 @@ describe("getEntitiesOfTable", () => {
         expect(result).to.eql(disableFollowTestTableAndThirdTableOnly);
       });
     });
+  });
 
+  describe("setting includeColumns", () => {
+    it("requires an array", () => {
+      expect(() => getEntitiesOfTable("testTable", {
+        pimUrl: SERVER_URL,
+        includeColumns: true
+      })).to.throw(/array of columns/i);
+    });
+
+    it("requires an array of strings", () => {
+      expect(() => getEntitiesOfTable("testTable", {
+        pimUrl: SERVER_URL,
+        includeColumns: [
+          "abc", 2, true
+        ]
+      })).to.throw(/array of columns/i);
+    });
+
+    it("should not download any links", () => {
+      return getEntitiesOfTable("testTable", {
+        pimUrl: SERVER_URL,
+        includeColumns: []
+      }).then(result => {
+        expect(result).to.eql(includeColumnsTestTableOnly);
+      });
+    });
+
+    it("should download specified link", () => {
+      return getEntitiesOfTable("testTable", {
+        pimUrl: SERVER_URL,
+        includeColumns: ["someLink"]
+      }).then(result => {
+        expect(result).to.eql(includeColumnsAllTables);
+      });
+    });
+
+    it("should not download specified link if it is disabled", () => {
+      return getEntitiesOfTable("testTable", {
+        pimUrl: SERVER_URL,
+        includeColumns: ["someLink"],
+        disableFollow: [["someLink"]]
+      }).then(result => {
+        expect(result).to.eql(includeColumnsTestTableOnly);
+      });
+    });
   });
 
 });


### PR DESCRIPTION
Erweiterung von `getEntitiesOfTable()` um die Option `includeColumns`. Wird nur auf der obersten Ebene ("Haupttabelle") ausgeführt, und die Einträge können mittels `disableFollow` explizit ausgeschlossen werden (macht wohl wenig Sinn, aber möglich ist es...).
Mit der Option kann verhindert werden, dass unnötige Informationen heruntergeladen werden, wenn man nur bestimmte Spalten benötigt, wie beispielsweise beim Bikeparts-Artikelexport.