### PR TITLE
Feat/get entities of tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 8.4.0 - Added `getEntitiesOfTables()` function
+
+* Extension of `getEntitiesOfTable()` function for multiple tables at once.
+
 ## 8.3.0 - Extended `getEntitiesOfTable()` function by `includeColumns` option
 
 * `includeColumns: String[]` option has been added for `getEntitiesOfTable()`. Specified as an array of strings, it

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ export default function start(step, progress, options) {
 
 #### `getEntitiesOfTable(tableName, options): Promise[GrudTables]`
 
-* `tableName` is the entry point for downloading all entities that are (recursively) linked.
-* `options` is an object consisting of the following options:
+* `tableName: String` is the entry point for downloading all entities that are (recursively) linked.
+* <span id="getentitiesoftable-options"></span>`options: Object` is an object consisting of the following options:
   * `pimUrl: String` (required) - The URL pointing to the GRUD instance.
   * `disableFollow: String[][]` (optional) - Defaults to empty array. An array of nested column lists that will not be 
     followed, i.e. `[["topLevelLinkColumn", "secondLevelLinkColumn"], ["anotherTopLevelLinkColumn]]`.
@@ -77,7 +77,16 @@ export default function start(step, progress, options) {
   * `maxEntriesPerRequest: number` (optional) - Defaults to 500. An integer greater than 0 to limit the amount of 
     work on each request done by the Grud instance. Higher values make less requests but may run into timeouts if the 
     Grud instance is not able to handle as much data.
-  * `headers`, `Object` (optional) - Defaults to {}. An object with key values pairs for http headers to set on every request.
+  * `headers: Object` (optional) - Defaults to {}. An object with key values pairs for http headers to set on every request.
+
+#### `getEntitiesOfTables(tableNames, options): Promise[GrudTables]`
+
+An extended version of [getEntitiesOfTable()](#getentitiesoftabletablename-options-promisegrudtables) for multiple
+tables at once. For a high amount of tables, this may result in a dramatic increase of performance as linked tables
+which are shared among initial tables will only be downloaded once.
+
+* `tableNames: String[]` - Table names for which all entities will be downloaded and recursively linked.
+* `options: Object` - See [options](#getentitiesoftable-options) of `getEntitiesOfTable()`.
 
 #### `filter(options): GrudTables => GrudTables`
 

--- a/lib/entities.js
+++ b/lib/entities.js
@@ -3,6 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports.getEntitiesOfTables = getEntitiesOfTables;
 exports.getEntitiesOfTable = getEntitiesOfTable;
 
 var _lodash = _interopRequireDefault(require("lodash"));
@@ -11,7 +12,20 @@ var _pimApi = require("./pimApi");
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-function getEntitiesOfTable(tableName) {
+function _toConsumableArray(arr) { return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _nonIterableSpread(); }
+
+function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance"); }
+
+function _iterableToArray(iter) { if (Symbol.iterator in Object(iter) || Object.prototype.toString.call(iter) === "[object Arguments]") return Array.from(iter); }
+
+function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = new Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } }
+
+function getEntitiesOfTables(tableNames) {
+  var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+  return getEntitiesOfTable(tableNames, options);
+}
+
+function getEntitiesOfTable(tableNameOrNames) {
   var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
   var _options$disableFollo = options.disableFollow,
       disableFollow = _options$disableFollo === void 0 ? [] : _options$disableFollo,
@@ -54,13 +68,18 @@ function getEntitiesOfTable(tableName) {
 
   var promises = {};
   var tables = {};
-  return (0, _pimApi.getTablesByNames)({
+
+  var tableNames = _lodash.default.concat(tableNameOrNames);
+
+  return _pimApi.getTablesByNames.apply(void 0, [{
     pimUrl: pimUrl,
     headers: headers
-  }, tableName).then(function (tablesFromPim) {
-    return Promise.all(_lodash.default.map(tablesFromPim, function (table) {
-      return getTableAndLinkedTablesAsPromise(table.id, disableFollow, maxEntriesPerRequest, includeColumns);
-    }));
+  }].concat(_toConsumableArray(tableNames))).then(function (tablesFromPim) {
+    return _lodash.default.reduce(tablesFromPim, function (accumulatorPromise, table) {
+      return accumulatorPromise.then(function () {
+        return getTableAndLinkedTablesAsPromise(table.id, disableFollow, maxEntriesPerRequest, includeColumns);
+      });
+    }, Promise.resolve([]));
   }).then(function () {
     return mapRowsOfTables(tables);
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tableaux-aggregator",
-  "version": "8.3.0",
+  "version": "8.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tableaux-aggregator",
-  "version": "8.3.0",
+  "version": "8.4.0",
   "description": "Core aggregator functions",
   "main": "lib/index.js",
   "files": [

--- a/src/__tests__/pimFixture-4-columns.json
+++ b/src/__tests__/pimFixture-4-columns.json
@@ -1,0 +1,18 @@
+{
+  "columns": [
+    {
+      "id": 1,
+      "name": "testColumn",
+      "kind": "shorttext",
+      "identifier": true,
+      "multilanguage": false,
+      "displayName": {
+        "en": "Some other text"
+      },
+      "description": {
+        "en": "A description of the simple text column in table 4"
+      }
+    }
+  ],
+  "status": "ok"
+}

--- a/src/__tests__/pimFixture-4-rows500.json
+++ b/src/__tests__/pimFixture-4-rows500.json
@@ -1,0 +1,16 @@
+{
+  "page": {
+    "offset": 0,
+    "limit": 500,
+    "totalSize": 1
+  },
+  "rows": [
+    {
+      "id": 1,
+      "values": [
+        "first row in table 4"
+      ]
+    }
+  ],
+  "status": "ok"
+}

--- a/src/__tests__/pimFixture-4-table.json
+++ b/src/__tests__/pimFixture-4-table.json
@@ -1,0 +1,17 @@
+{
+  "id": 4,
+  "name": "fooTestTable",
+  "displayName": {
+    "de": "Test Tabelle FOO",
+    "en": "Test table FOO"
+  },
+  "description": {
+    "de": "Eine Tabelle FOO zum Testen",
+    "en": "A table FOO to test"
+  },
+  "langtags": [
+    "de",
+    "en"
+  ],
+  "status": "ok"
+}

--- a/src/__tests__/pimFixture-4.json
+++ b/src/__tests__/pimFixture-4.json
@@ -1,0 +1,39 @@
+{
+  "id": 4,
+  "name": "fooTestTable",
+  "displayName": {
+    "de": "Test Tabelle FOO",
+    "en": "Test table FOO"
+  },
+  "description": {
+    "de": "Eine Tabelle FOO zum Testen",
+    "en": "A table FOO to test"
+  },
+  "langtags": [
+    "de",
+    "en"
+  ],
+  "columns": [
+    {
+      "id": 1,
+      "name": "testColumn",
+      "kind": "shorttext",
+      "identifier": true,
+      "multilanguage": false,
+      "displayName": {
+        "en": "Some other text"
+      },
+      "description": {
+        "en": "A description of the simple text column in table 4"
+      }
+    }
+  ],
+  "rows": [
+    {
+      "id": 1,
+      "values": [
+        "first row in table 4"
+      ]
+    }
+  ]
+}

--- a/src/__tests__/pimFixture-5-columns.json
+++ b/src/__tests__/pimFixture-5-columns.json
@@ -1,0 +1,18 @@
+{
+  "columns": [
+    {
+      "id": 1,
+      "name": "testColumn",
+      "kind": "shorttext",
+      "identifier": true,
+      "multilanguage": false,
+      "displayName": {
+        "en": "Some other text"
+      },
+      "description": {
+        "en": "A description of the simple text column in table 5"
+      }
+    }
+  ],
+  "status": "ok"
+}

--- a/src/__tests__/pimFixture-5-rows500.json
+++ b/src/__tests__/pimFixture-5-rows500.json
@@ -1,0 +1,16 @@
+{
+  "page": {
+    "offset": 0,
+    "limit": 500,
+    "totalSize": 1
+  },
+  "rows": [
+    {
+      "id": 1,
+      "values": [
+        "first row in table 5"
+      ]
+    }
+  ],
+  "status": "ok"
+}

--- a/src/__tests__/pimFixture-5-table.json
+++ b/src/__tests__/pimFixture-5-table.json
@@ -1,0 +1,17 @@
+{
+  "id": 5,
+  "name": "quxTestTable",
+  "displayName": {
+    "de": "Test Tabelle QUX",
+    "en": "Test table QUX"
+  },
+  "description": {
+    "de": "Eine Tabelle QUX zum Testen",
+    "en": "A table QUX to test"
+  },
+  "langtags": [
+    "de",
+    "en"
+  ],
+  "status": "ok"
+}

--- a/src/__tests__/pimFixture-5.json
+++ b/src/__tests__/pimFixture-5.json
@@ -1,0 +1,39 @@
+{
+  "id": 5,
+  "name": "quxTestTable",
+  "displayName": {
+    "de": "Test Tabelle QUX",
+    "en": "Test table QUX"
+  },
+  "description": {
+    "de": "Eine Tabelle QUX zum Testen",
+    "en": "A table QUX to test"
+  },
+  "langtags": [
+    "de",
+    "en"
+  ],
+  "columns": [
+    {
+      "id": 1,
+      "name": "testColumn",
+      "kind": "shorttext",
+      "identifier": true,
+      "multilanguage": false,
+      "displayName": {
+        "en": "Some other text"
+      },
+      "description": {
+        "en": "A description of the simple text column in table 5"
+      }
+    }
+  ],
+  "rows": [
+    {
+      "id": 1,
+      "values": [
+        "first row in table 5"
+      ]
+    }
+  ]
+}

--- a/src/__tests__/pimFixture-alltables.json
+++ b/src/__tests__/pimFixture-alltables.json
@@ -45,6 +45,38 @@
         "de",
         "en"
       ]
+    },
+    {
+      "id": 4,
+      "name": "fooTestTable",
+      "displayName": {
+        "de": "Test Tabelle FOO",
+        "en": "Test table FOO"
+      },
+      "description": {
+        "de": "Eine Tabelle FOO zum Testen",
+        "en": "A table FOO to test"
+      },
+      "langtags": [
+        "de",
+        "en"
+      ]
+    },
+    {
+      "id": 5,
+      "name": "quxTestTable",
+      "displayName": {
+        "de": "Test Tabelle QUX",
+        "en": "Test table QUX"
+      },
+      "description": {
+        "de": "Eine Tabelle QUX zum Testen",
+        "en": "A table QUX to test"
+      },
+      "langtags": [
+        "de",
+        "en"
+      ]
     }
   ],
   "status": "ok"

--- a/src/entities.spec.js
+++ b/src/entities.spec.js
@@ -1,12 +1,13 @@
 import expect from "must";
 import express from "express";
-import {getEntitiesOfTable} from "./entities";
+import {getEntitiesOfTable, getEntitiesOfTables} from "./entities";
 import disableFollowTestTableOnly from "./__tests__/testTableDisableFollow1.json";
 import disableFollowTestTableAndThirdTableOnly from "./__tests__/testTableDisableFollow2.json";
 import includeColumnsTestTableOnly from "./__tests__/testTableIncludeColumns1.json";
 import includeColumnsAllTables from "./__tests__/testTableIncludeColumns2.json";
 
-describe("getEntitiesOfTable", () => {
+describe("entities.js", () => {
+  const TABLE_IDS = [1, 2, 3, 4, 5];
 
   const TEST_PORT = 14432;
   const SERVER_URL = `http://localhost:${TEST_PORT}`;
@@ -14,54 +15,35 @@ describe("getEntitiesOfTable", () => {
   let calledUrls;
 
   before(() => {
+    const DATA_BY_URL = {
+      "/tables": "pimFixture-alltables.json"
+    };
+
+    TABLE_IDS.forEach(id => Object.assign(DATA_BY_URL, {
+      [`/completetable/${id}`]: `pimFixture-${id}.json`,
+      [`/tables/${id}`]: `pimFixture-${id}-table.json`,
+      [`/tables/${id}/columns`]: `pimFixture-${id}-columns.json`,
+      [`/tables/${id}/rows?offset=0&limit=500`]: `pimFixture-${id}-rows500.json`,
+      [`/tables/${id}/rows?offset=0&limit=2`]: `pimFixture-${id}-rows1.json`,
+      [`/tables/${id}/rows?offset=2&limit=2`]: `pimFixture-${id}-rows2.json`,
+      [`/tables/${id}/rows?offset=4&limit=2`]: `pimFixture-${id}-rows3.json`
+    }));
+
     return new Promise((resolve, reject) => {
       const app = express();
+
       app.use((req, res) => {
         calledUrls.push(req.url);
-        if (req.url === "/tables") {
-          res.sendFile(`${__dirname}/__tests__/pimFixture-alltables.json`);
-        } else if (req.url === "/completetable/1") {
-          res.sendFile(`${__dirname}/__tests__/pimFixture-1.json`);
-        } else if (req.url === "/completetable/2") {
-          res.sendFile(`${__dirname}/__tests__/pimFixture-2.json`);
-        } else if (req.url === "/completetable/3") {
-          res.sendFile(`${__dirname}/__tests__/pimFixture-3.json`);
-        } else if (req.url === "/tables/1") {
-          res.sendFile(`${__dirname}/__tests__/pimFixture-1-table.json`);
-        } else if (req.url === "/tables/2") {
-          res.sendFile(`${__dirname}/__tests__/pimFixture-2-table.json`);
-        } else if (req.url === "/tables/3") {
-          res.sendFile(`${__dirname}/__tests__/pimFixture-3-table.json`);
-        } else if (req.url === "/tables/1/columns") {
-          res.sendFile(`${__dirname}/__tests__/pimFixture-1-columns.json`);
-        } else if (req.url === "/tables/2/columns") {
-          res.sendFile(`${__dirname}/__tests__/pimFixture-2-columns.json`);
-        } else if (req.url === "/tables/3/columns") {
-          res.sendFile(`${__dirname}/__tests__/pimFixture-3-columns.json`);
-        } else if (req.url === "/tables/1/rows?offset=0&limit=500") {
-          res.sendFile(`${__dirname}/__tests__/pimFixture-1-rows500.json`);
-        } else if (req.url === "/tables/2/rows?offset=0&limit=500") {
-          res.sendFile(`${__dirname}/__tests__/pimFixture-2-rows500.json`);
-        } else if (req.url === "/tables/3/rows?offset=0&limit=500") {
-          res.sendFile(`${__dirname}/__tests__/pimFixture-3-rows500.json`);
-        } else if (req.url === "/tables/1/rows?offset=0&limit=2") {
-          res.sendFile(`${__dirname}/__tests__/pimFixture-1-rows1.json`);
-        } else if (req.url === "/tables/2/rows?offset=0&limit=2") {
-          res.sendFile(`${__dirname}/__tests__/pimFixture-2-rows1.json`);
-        } else if (req.url === "/tables/3/rows?offset=0&limit=2") {
-          res.sendFile(`${__dirname}/__tests__/pimFixture-3-rows1.json`);
-        } else if (req.url === "/tables/1/rows?offset=2&limit=2") {
-          res.sendFile(`${__dirname}/__tests__/pimFixture-1-rows2.json`);
-        } else if (req.url === "/tables/2/rows?offset=2&limit=2") {
-          res.sendFile(`${__dirname}/__tests__/pimFixture-2-rows2.json`);
-        } else if (req.url === "/tables/3/rows?offset=2&limit=2") {
-          res.sendFile(`${__dirname}/__tests__/pimFixture-3-rows2.json`);
-        } else if (req.url === "/tables/3/rows?offset=4&limit=2") {
-          res.sendFile(`${__dirname}/__tests__/pimFixture-3-rows3.json`);
-        } else {
+
+        const data = DATA_BY_URL[req.url];
+
+        if (!data) {
           res.end("error");
+        } else {
+          res.sendFile(`${__dirname}/__tests__/${data}`);
         }
       });
+
       server = app.listen(TEST_PORT, function (err) {
         if (err) {
           return reject(err);
@@ -80,180 +62,211 @@ describe("getEntitiesOfTable", () => {
     server.close(done);
   });
 
-  it("finds the server with all entities", () => {
-    return getEntitiesOfTable("testTable", {pimUrl: SERVER_URL})
-      .then(result => {
-        expect(Object.keys(result)).to.eql(["1", "2", "3"]);
-      });
-  });
+  describe("getEntitiesOfTables", () => {
+    it("retrieves entities of multiple tables", () => {
+      return getEntitiesOfTables(["testTable", "fooTestTable", "quxTestTable"], {pimUrl: SERVER_URL})
+        .then(result => {
+          expect(Object.keys(result)).to.eql(TABLE_IDS.map(String));
 
-  it("maps the rows to their object ids", () => {
-    return getEntitiesOfTable("testTable", {pimUrl: SERVER_URL})
-      .then(result => {
-        expect(result["1"].rows).not.to.be.an.array();
-        expect(result["1"].rows).to.be.an.object();
-        expect(Object.keys(result["1"].rows)).to.eql(["1", "2", "3", "4"]);
-      });
-  });
-
-  it("requires a pimUrl", () => {
-    expect(() => getEntitiesOfTable("someTable")).to.throw(/missing option pimUrl/i);
-  });
-
-  it("requires a pimUrl as string", () => {
-    expect(() => getEntitiesOfTable("testTable", {pimUrl: true})).to.throw(/pimUrl.*string/i);
-    expect(() => getEntitiesOfTable("testTable", {pimUrl: false})).to.throw(/pimUrl.*string/i);
-    expect(() => getEntitiesOfTable("testTable", {pimUrl: []})).to.throw(/pimUrl.*string/i);
-    expect(() => getEntitiesOfTable("testTable", {pimUrl: 123})).to.throw(/pimUrl.*string/i);
-    return expect(getEntitiesOfTable("testTable", {pimUrl: SERVER_URL})).to.resolve.not.to.null();
-  });
-
-  describe("maxEntriesPerRequest setting", () => {
-
-    it("may download in a paged fashion", () => {
-      return getEntitiesOfTable("testTable", {
-        pimUrl: SERVER_URL,
-        maxEntriesPerRequest: 2
-      }).then(result => {
-        expect(calledUrls.some(elem => /\/completetable\//.test(elem))).to.be.false();
-        expect(calledUrls.some(elem => /\/tables\/1\/columns/.test(elem))).to.be.true();
-        expect(calledUrls.some(elem => /\/tables\/1\/rows\?offset=0&limit=2/.test(elem))).to.be.true();
-        expect(calledUrls.some(elem => /\/tables\/1\/rows\?offset=2&limit=2/.test(elem))).to.be.true();
-        expect(calledUrls.some(elem => /\/tables\/2\/columns/.test(elem))).to.be.true();
-        expect(calledUrls.some(elem => /\/tables\/2\/rows\?offset=0&limit=2/.test(elem))).to.be.true();
-        expect(calledUrls.some(elem => /\/tables\/2\/rows\?offset=2&limit=2/.test(elem))).to.be.true();
-        expect(calledUrls.some(elem => /\/tables\/3\/columns/.test(elem))).to.be.true();
-        expect(calledUrls.some(elem => /\/tables\/3\/rows\?offset=0&limit=2/.test(elem))).to.be.true();
-        expect(calledUrls.some(elem => /\/tables\/3\/rows\?offset=2&limit=2/.test(elem))).to.be.true();
-        expect(calledUrls.some(elem => /\/tables\/3\/rows\?offset=4&limit=2/.test(elem))).to.be.true();
-
-        expect(result["1"].rows).not.to.be.an.array();
-        expect(result["1"].rows).to.be.an.object();
-        expect(Object.keys(result["1"].rows)).to.eql(["1", "2", "3", "4"]);
-      });
+          TABLE_IDS.forEach(id => {
+            expect(result[id].rows).not.to.be.empty();
+            expect(result[id].columns).not.to.be.empty();
+          });
+        });
     });
 
-    it("will throw on a negative number", () => {
-      expect(() => getEntitiesOfTable("testTable", {
-        pimUrl: SERVER_URL,
-        maxEntriesPerRequest: -1
-      })).to.throw();
-      expect(() => getEntitiesOfTable("testTable", {
-        pimUrl: SERVER_URL,
-        maxEntriesPerRequest: -5143
-      })).to.throw();
-    });
+    it("maps the rows to their object ids for multiple tables", () => {
+      return getEntitiesOfTables(["testTable", "fooTestTable", "quxTestTable"], {pimUrl: SERVER_URL})
+        .then(result => {
+          TABLE_IDS.forEach(id => {
+            expect(result[id].rows).to.be.an.object();
+          });
 
-    it("will throw on NaN", () => {
-      expect(() => getEntitiesOfTable("testTable", {
-        pimUrl: SERVER_URL,
-        maxEntriesPerRequest: NaN
-      })).to.throw();
-      expect(() => getEntitiesOfTable("testTable", {
-        pimUrl: SERVER_URL,
-        maxEntriesPerRequest: "hello"
-      })).to.throw();
-    });
-
-    it("will throw on non-integer values", () => {
-      expect(() => getEntitiesOfTable("testTable", {
-        pimUrl: SERVER_URL,
-        maxEntriesPerRequest: 0.5
-      })).to.throw();
-      expect(() => getEntitiesOfTable("testTable", {
-        pimUrl: SERVER_URL,
-        maxEntriesPerRequest: -6.5
-      })).to.throw();
-      expect(() => getEntitiesOfTable("testTable", {
-        pimUrl: SERVER_URL,
-        maxEntriesPerRequest: Math.PI
-      })).to.throw();
-    });
-
-  });
-
-  describe("setting disableFollow", () => {
-    it("requires an array", () => {
-      expect(() => getEntitiesOfTable("testTable", {
-        pimUrl: SERVER_URL,
-        disableFollow: true
-      })).to.throw(/array of column lists/i);
-    });
-
-    it("requires an array of arrays", () => {
-      expect(() => getEntitiesOfTable("testTable", {
-        pimUrl: SERVER_URL,
-        disableFollow: [
-          "abc", 2, true
-        ]
-      })).to.throw(/array of column lists/i);
-    });
-
-    it("should not download the specified links", () => {
-      return getEntitiesOfTable("testTable", {
-        pimUrl: SERVER_URL,
-        disableFollow: [
-          ["someLink"]
-        ]
-      }).then(result => {
-        expect(result).to.eql(disableFollowTestTableOnly);
-      });
-    });
-
-    it("should not download specified links in sub-tables if defined", () => {
-      return getEntitiesOfTable("testTable", {
-        pimUrl: SERVER_URL,
-        disableFollow: [
-          ["someLink", "anotherLink"]
-        ]
-      }).then(result => {
-        expect(result).to.eql(disableFollowTestTableAndThirdTableOnly);
-      });
+          expect(Object.keys(result["1"].rows)).to.eql(["1", "2", "3", "4"]);
+          expect(Object.keys(result["2"].rows)).to.eql(["1", "2", "3"]);
+          expect(Object.keys(result["3"].rows)).to.eql(["1", "2", "3", "4", "5"]);
+          expect(Object.keys(result["4"].rows)).to.eql(["1"]);
+          expect(Object.keys(result["5"].rows)).to.eql(["1"]);
+        });
     });
   });
 
-  describe("setting includeColumns", () => {
-    it("requires an array", () => {
-      expect(() => getEntitiesOfTable("testTable", {
-        pimUrl: SERVER_URL,
-        includeColumns: true
-      })).to.throw(/array of columns/i);
+  describe("getEntitiesOfTable", () => {
+    it("retrieves entities of a test table", () => {
+      return getEntitiesOfTable("testTable", {pimUrl: SERVER_URL})
+        .then(result => {
+          expect(Object.keys(result)).to.eql(["1", "2", "3"]);
+        });
     });
 
-    it("requires an array of strings", () => {
-      expect(() => getEntitiesOfTable("testTable", {
-        pimUrl: SERVER_URL,
-        includeColumns: [
-          "abc", 2, true
-        ]
-      })).to.throw(/array of columns/i);
+    it("maps the rows to their object ids", () => {
+      return getEntitiesOfTable("testTable", {pimUrl: SERVER_URL})
+        .then(result => {
+          expect(result["1"].rows).not.to.be.an.array();
+          expect(result["1"].rows).to.be.an.object();
+          expect(Object.keys(result["1"].rows)).to.eql(["1", "2", "3", "4"]);
+        });
     });
 
-    it("should not download any links", () => {
-      return getEntitiesOfTable("testTable", {
-        pimUrl: SERVER_URL,
-        includeColumns: []
-      }).then(result => {
-        expect(result).to.eql(includeColumnsTestTableOnly);
+    it("requires a pimUrl", () => {
+      expect(() => getEntitiesOfTable("someTable")).to.throw(/missing option pimUrl/i);
+    });
+
+    it("requires a pimUrl as string", () => {
+      expect(() => getEntitiesOfTable("testTable", {pimUrl: true})).to.throw(/pimUrl.*string/i);
+      expect(() => getEntitiesOfTable("testTable", {pimUrl: false})).to.throw(/pimUrl.*string/i);
+      expect(() => getEntitiesOfTable("testTable", {pimUrl: []})).to.throw(/pimUrl.*string/i);
+      expect(() => getEntitiesOfTable("testTable", {pimUrl: 123})).to.throw(/pimUrl.*string/i);
+      return expect(getEntitiesOfTable("testTable", {pimUrl: SERVER_URL})).to.resolve.not.to.null();
+    });
+
+    describe("maxEntriesPerRequest setting", () => {
+
+      it("may download in a paged fashion", () => {
+        return getEntitiesOfTable("testTable", {
+          pimUrl: SERVER_URL,
+          maxEntriesPerRequest: 2
+        }).then(result => {
+          expect(calledUrls.some(elem => /\/completetable\//.test(elem))).to.be.false();
+          expect(calledUrls.some(elem => /\/tables\/1\/columns/.test(elem))).to.be.true();
+          expect(calledUrls.some(elem => /\/tables\/1\/rows\?offset=0&limit=2/.test(elem))).to.be.true();
+          expect(calledUrls.some(elem => /\/tables\/1\/rows\?offset=2&limit=2/.test(elem))).to.be.true();
+          expect(calledUrls.some(elem => /\/tables\/2\/columns/.test(elem))).to.be.true();
+          expect(calledUrls.some(elem => /\/tables\/2\/rows\?offset=0&limit=2/.test(elem))).to.be.true();
+          expect(calledUrls.some(elem => /\/tables\/2\/rows\?offset=2&limit=2/.test(elem))).to.be.true();
+          expect(calledUrls.some(elem => /\/tables\/3\/columns/.test(elem))).to.be.true();
+          expect(calledUrls.some(elem => /\/tables\/3\/rows\?offset=0&limit=2/.test(elem))).to.be.true();
+          expect(calledUrls.some(elem => /\/tables\/3\/rows\?offset=2&limit=2/.test(elem))).to.be.true();
+          expect(calledUrls.some(elem => /\/tables\/3\/rows\?offset=4&limit=2/.test(elem))).to.be.true();
+
+          expect(result["1"].rows).not.to.be.an.array();
+          expect(result["1"].rows).to.be.an.object();
+          expect(Object.keys(result["1"].rows)).to.eql(["1", "2", "3", "4"]);
+        });
+      });
+
+      it("will throw on a negative number", () => {
+        expect(() => getEntitiesOfTable("testTable", {
+          pimUrl: SERVER_URL,
+          maxEntriesPerRequest: -1
+        })).to.throw();
+        expect(() => getEntitiesOfTable("testTable", {
+          pimUrl: SERVER_URL,
+          maxEntriesPerRequest: -5143
+        })).to.throw();
+      });
+
+      it("will throw on NaN", () => {
+        expect(() => getEntitiesOfTable("testTable", {
+          pimUrl: SERVER_URL,
+          maxEntriesPerRequest: NaN
+        })).to.throw();
+        expect(() => getEntitiesOfTable("testTable", {
+          pimUrl: SERVER_URL,
+          maxEntriesPerRequest: "hello"
+        })).to.throw();
+      });
+
+      it("will throw on non-integer values", () => {
+        expect(() => getEntitiesOfTable("testTable", {
+          pimUrl: SERVER_URL,
+          maxEntriesPerRequest: 0.5
+        })).to.throw();
+        expect(() => getEntitiesOfTable("testTable", {
+          pimUrl: SERVER_URL,
+          maxEntriesPerRequest: -6.5
+        })).to.throw();
+        expect(() => getEntitiesOfTable("testTable", {
+          pimUrl: SERVER_URL,
+          maxEntriesPerRequest: Math.PI
+        })).to.throw();
+      });
+
+    });
+
+    describe("setting disableFollow", () => {
+      it("requires an array", () => {
+        expect(() => getEntitiesOfTable("testTable", {
+          pimUrl: SERVER_URL,
+          disableFollow: true
+        })).to.throw(/array of column lists/i);
+      });
+
+      it("requires an array of arrays", () => {
+        expect(() => getEntitiesOfTable("testTable", {
+          pimUrl: SERVER_URL,
+          disableFollow: [
+            "abc", 2, true
+          ]
+        })).to.throw(/array of column lists/i);
+      });
+
+      it("should not download the specified links", () => {
+        return getEntitiesOfTable("testTable", {
+          pimUrl: SERVER_URL,
+          disableFollow: [
+            ["someLink"]
+          ]
+        }).then(result => {
+          expect(result).to.eql(disableFollowTestTableOnly);
+        });
+      });
+
+      it("should not download specified links in sub-tables if defined", () => {
+        return getEntitiesOfTable("testTable", {
+          pimUrl: SERVER_URL,
+          disableFollow: [
+            ["someLink", "anotherLink"]
+          ]
+        }).then(result => {
+          expect(result).to.eql(disableFollowTestTableAndThirdTableOnly);
+        });
       });
     });
 
-    it("should download specified link", () => {
-      return getEntitiesOfTable("testTable", {
-        pimUrl: SERVER_URL,
-        includeColumns: ["someLink"]
-      }).then(result => {
-        expect(result).to.eql(includeColumnsAllTables);
+    describe("setting includeColumns", () => {
+      it("requires an array", () => {
+        expect(() => getEntitiesOfTable("testTable", {
+          pimUrl: SERVER_URL,
+          includeColumns: true
+        })).to.throw(/array of columns/i);
       });
-    });
 
-    it("should not download specified link if it is disabled", () => {
-      return getEntitiesOfTable("testTable", {
-        pimUrl: SERVER_URL,
-        includeColumns: ["someLink"],
-        disableFollow: [["someLink"]]
-      }).then(result => {
-        expect(result).to.eql(includeColumnsTestTableOnly);
+      it("requires an array of strings", () => {
+        expect(() => getEntitiesOfTable("testTable", {
+          pimUrl: SERVER_URL,
+          includeColumns: [
+            "abc", 2, true
+          ]
+        })).to.throw(/array of columns/i);
+      });
+
+      it("should not download any links", () => {
+        return getEntitiesOfTable("testTable", {
+          pimUrl: SERVER_URL,
+          includeColumns: []
+        }).then(result => {
+          expect(result).to.eql(includeColumnsTestTableOnly);
+        });
+      });
+
+      it("should download specified link", () => {
+        return getEntitiesOfTable("testTable", {
+          pimUrl: SERVER_URL,
+          includeColumns: ["someLink"]
+        }).then(result => {
+          expect(result).to.eql(includeColumnsAllTables);
+        });
+      });
+
+      it("should not download specified link if it is disabled", () => {
+        return getEntitiesOfTable("testTable", {
+          pimUrl: SERVER_URL,
+          includeColumns: ["someLink"],
+          disableFollow: [["someLink"]]
+        }).then(result => {
+          expect(result).to.eql(includeColumnsTestTableOnly);
+        });
       });
     });
   });


### PR DESCRIPTION
Aktuell haben wir nur `getEntitiesOfTable()`, womit nur eine Tabelle verabreitet werden kann. Falls diese Funktion jedoch mehrmals hintereinander auf unterschiedliche Tabellen angewandt wird, so werden u. U. gleiche verlinkte Tabellen mehrfach heruntergeladen.

Mit der Erweiterung um `getEntitiesOfTables()` soll ermögicht werden, dass gleichzeitig mehrere Tabellen verarbeitet. Durch die Zwischenspeicherung der verlinkten Tabellen (die Funktionalität ist bereits vorhanden) wird eine Performance-Steigerung bei der Veerarbeitung großer Anzahl an Tabellen erwartet (z.B. Artikelexport bei BikeParts).