### PR TITLE
feat: add includeArchived option to getEntitiesOfTable

### DIFF
--- a/lib/entities.js
+++ b/lib/entities.js
@@ -33,6 +33,8 @@ function getEntitiesOfTable(tableNameOrNames) {
       pimUrl = options.pimUrl,
       _options$maxEntriesPe = options.maxEntriesPerRequest,
       maxEntriesPerRequest = _options$maxEntriesPe === void 0 ? 500 : _options$maxEntriesPe,
+      _options$includeArchi = options.includeArchived,
+      includeArchived = _options$includeArchi === void 0 ? true : _options$includeArchi,
       _options$headers = options.headers,
       headers = _options$headers === void 0 ? {} : _options$headers;
 
@@ -60,6 +62,10 @@ function getEntitiesOfTable(tableNameOrNames) {
     throw new Error("Expecting maxEntriesPerRequest to be a positive integer greater than 0");
   }
 
+  if (!_lodash.default.isBoolean(includeArchived)) {
+    throw new Error("Expecting includeArchived to be a boolean");
+  }
+
   if (!_lodash.default.isPlainObject(headers) || _lodash.default.some(headers, function (value) {
     return !_lodash.default.isString(value);
   })) {
@@ -77,19 +83,19 @@ function getEntitiesOfTable(tableNameOrNames) {
   }].concat(_toConsumableArray(tableNames))).then(function (tablesFromPim) {
     return _lodash.default.reduce(tablesFromPim, function (accumulatorPromise, table) {
       return accumulatorPromise.then(function () {
-        return getTableAndLinkedTablesAsPromise(table.id, disableFollow, maxEntriesPerRequest, includeColumns);
+        return getTableAndLinkedTablesAsPromise(table.id, disableFollow, maxEntriesPerRequest, includeArchived, includeColumns);
       });
     }, Promise.resolve([]));
   }).then(function () {
     return mapRowsOfTables(tables);
   });
 
-  function getTableAndLinkedTablesAsPromise(tableId, disableFollow, maxEntriesPerRequest, includeColumns) {
+  function getTableAndLinkedTablesAsPromise(tableId, disableFollow, maxEntriesPerRequest, includeArchived, includeColumns) {
     if (!promises[tableId]) {
       var promiseOfLinkedTables = (0, _pimApi.getCompleteTable)({
         pimUrl: pimUrl,
         headers: headers
-      }, tableId, maxEntriesPerRequest).then(function (table) {
+      }, tableId, maxEntriesPerRequest, includeArchived).then(function (table) {
         tables[tableId] = table;
 
         var columnsToFollow = _lodash.default.filter(table.columns, function (_ref) {
@@ -108,7 +114,7 @@ function getEntitiesOfTable(tableNameOrNames) {
             return _lodash.default.tail(columns);
           });
 
-          return getTableAndLinkedTablesAsPromise(column.toTable, nextDisableFollow, maxEntriesPerRequest);
+          return getTableAndLinkedTablesAsPromise(column.toTable, nextDisableFollow, maxEntriesPerRequest, includeArchived);
         }));
       });
       promises[tableId] = promiseOfLinkedTables;

--- a/lib/pimApi.js
+++ b/lib/pimApi.js
@@ -47,6 +47,8 @@ function getTablesByNames(options) {
 }
 
 function getCompleteTable(options, tableId, maxEntries) {
+  var includeArchived = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : true;
+
   var _getOptionsFromParam2 = getOptionsFromParam(options, "getAllTables"),
       pimUrl = _getOptionsFromParam2.pimUrl,
       _getOptionsFromParam3 = _getOptionsFromParam2.headers,
@@ -58,6 +60,10 @@ function getCompleteTable(options, tableId, maxEntries) {
 
   if (!_lodash.default.isInteger(maxEntries) || maxEntries <= 0) {
     throw new Error("Expecting maxEntriesPerRequest to be a positive integer greater than 0");
+  }
+
+  if (!_lodash.default.isBoolean(includeArchived)) {
+    throw new Error("Expecting includeArchived to be a boolean");
   }
 
   return request("GET", "".concat(pimUrl, "/tables/").concat(tableId), {
@@ -73,12 +79,14 @@ function getCompleteTable(options, tableId, maxEntries) {
       });
     });
   }).then(function (tableAndColumns) {
-    return request("GET", "".concat(pimUrl, "/tables/").concat(tableId, "/rows?offset=0&limit=").concat(maxEntries), {
+    var archivedQuery = includeArchived ? "" : "&archived=".concat(includeArchived);
+    var url = "".concat(pimUrl, "/tables/").concat(tableId, "/rows?offset=0&limit=").concat(maxEntries).concat(archivedQuery);
+    return request("GET", url, {
       headers: headers
     }).then(function (result) {
       var totalSize = result.page.totalSize;
       var elements = Math.ceil(totalSize / maxEntries);
-      var requests = createArrayOfRequests(pimUrl, tableId, maxEntries, elements);
+      var requests = createArrayOfRequests(pimUrl, tableId, maxEntries, elements, archivedQuery);
       return requests.reduce(function (promise, requestUrl) {
         return promise.then(function (tableColumnsAndRows) {
           return request("GET", requestUrl, {
@@ -117,11 +125,11 @@ function getOptionsFromParam(options, fnName) {
   }
 }
 
-function createArrayOfRequests(pimUrl, tableId, maxEntries, elements) {
+function createArrayOfRequests(pimUrl, tableId, maxEntries, elements, archivedQuery) {
   var arr = [];
 
   for (var i = 0; i < elements - 1; i++) {
-    arr.push("".concat(pimUrl, "/tables/").concat(tableId, "/rows?offset=").concat((i + 1) * maxEntries, "&limit=").concat(maxEntries));
+    arr.push("".concat(pimUrl, "/tables/").concat(tableId, "/rows?offset=").concat((i + 1) * maxEntries, "&limit=").concat(maxEntries).concat(archivedQuery));
   }
 
   return arr;

--- a/src/entities.spec.js
+++ b/src/entities.spec.js
@@ -24,6 +24,7 @@ describe("entities.js", () => {
       [`/tables/${id}`]: `pimFixture-${id}-table.json`,
       [`/tables/${id}/columns`]: `pimFixture-${id}-columns.json`,
       [`/tables/${id}/rows?offset=0&limit=500`]: `pimFixture-${id}-rows500.json`,
+      [`/tables/${id}/rows?offset=0&limit=500&archived=false`]: `pimFixture-${id}-rows500.json`,
       [`/tables/${id}/rows?offset=0&limit=2`]: `pimFixture-${id}-rows1.json`,
       [`/tables/${id}/rows?offset=2&limit=2`]: `pimFixture-${id}-rows2.json`,
       [`/tables/${id}/rows?offset=4&limit=2`]: `pimFixture-${id}-rows3.json`
@@ -269,6 +270,54 @@ describe("entities.js", () => {
         });
       });
     });
+
+    describe("setting includeArchived", () => {
+      it("requires a boolean", () => {
+        expect(() => getEntitiesOfTable("testTable", {
+          pimUrl: SERVER_URL,
+          includeArchived: "false"
+        })).to.throw(/boolean/i);
+      });
+
+      it("should not include archived query in URL of rows API call", () => {
+        return getEntitiesOfTable("testTable", {
+          pimUrl: SERVER_URL,
+          includeArchived: true
+        }).then(result => {
+          expect(calledUrls.some(elem => /\/completetable\//.test(elem))).to.be.false();
+          expect(calledUrls.some(elem => /\/tables\/1\/columns/.test(elem))).to.be.true();
+          expect(calledUrls.some(elem => /\/tables\/1\/rows\?offset=0&limit=500/.test(elem))).to.be.true();
+          expect(calledUrls.some(elem => /\/tables\/2\/columns/.test(elem))).to.be.true();
+          expect(calledUrls.some(elem => /\/tables\/2\/rows\?offset=0&limit=500/.test(elem))).to.be.true();
+          expect(calledUrls.some(elem => /\/tables\/3\/columns/.test(elem))).to.be.true();
+          expect(calledUrls.some(elem => /\/tables\/3\/rows\?offset=0&limit=500/.test(elem))).to.be.true();
+
+          expect(result["1"].rows).not.to.be.an.array();
+          expect(result["1"].rows).to.be.an.object();
+          expect(Object.keys(result["1"].rows)).to.eql(["1", "2", "3", "4"]);
+        });
+      });
+
+      it("should include archived query in URL of rows API call", () => {
+        return getEntitiesOfTable("testTable", {
+          pimUrl: SERVER_URL,
+          includeArchived: false
+        }).then(result => {
+          expect(calledUrls.some(elem => /\/completetable\//.test(elem))).to.be.false();
+          expect(calledUrls.some(elem => /\/tables\/1\/columns/.test(elem))).to.be.true();
+          expect(calledUrls.some(elem => /\/tables\/1\/rows\?offset=0&limit=500&archived=false/.test(elem))).to.be.true();
+          expect(calledUrls.some(elem => /\/tables\/2\/columns/.test(elem))).to.be.true();
+          expect(calledUrls.some(elem => /\/tables\/2\/rows\?offset=0&limit=500&archived=false/.test(elem))).to.be.true();
+          expect(calledUrls.some(elem => /\/tables\/3\/columns/.test(elem))).to.be.true();
+          expect(calledUrls.some(elem => /\/tables\/3\/rows\?offset=0&limit=500&archived=false/.test(elem))).to.be.true();
+
+          expect(result["1"].rows).not.to.be.an.array();
+          expect(result["1"].rows).to.be.an.object();
+          expect(Object.keys(result["1"].rows)).to.eql(["1", "2", "3", "4"]);
+        });
+      });
+    });
+
   });
 
 });

--- a/src/pimApi.spec.js
+++ b/src/pimApi.spec.js
@@ -1,3 +1,4 @@
+
 import expect from "must";
 import express from "express";
 import {getAllTables, getTablesByNames, getCompleteTable} from "./pimApi";
@@ -31,6 +32,8 @@ describe("pimApi", () => {
         } else if (req.url === "/tables/3/rows?offset=2&limit=2") {
           res.sendFile(`${__dirname}/__tests__/pimFixture-3-rows2.json`);
         } else if (req.url === "/tables/3/rows?offset=4&limit=2") {
+          res.sendFile(`${__dirname}/__tests__/pimFixture-3-rows3.json`);
+        } else if (req.url === "/tables/3/rows?offset=0&limit=2&archived=false") {
           res.sendFile(`${__dirname}/__tests__/pimFixture-3-rows3.json`);
         } else {
           res.end("error");
@@ -172,6 +175,46 @@ describe("pimApi", () => {
         expect(result).to.have.property("rows");
         expect(result.rows).to.be.an.array();
         expect(result.rows.length).to.equal(5);
+      });
+    });
+
+    it("should construct the correct URL for the rows API call without setting the includeArchived parameter", () => {
+      return getCompleteTable({
+        pimUrl: SERVER_URL
+      }, 3, 2).then(result => {
+        expect(calledUrls.some(elem => /\/tables\/3\/rows\?offset=0&limit=2/.test(elem))).to.be.true();
+
+        expect(result).to.have.property("id");
+        expect(result.name).to.equal("thirdTestTable");
+        expect(result).to.have.property("rows");
+        expect(result.rows).to.be.an.array();
+      });
+    });
+
+    it("should construct the correct URL for the rows API call with includeArchived parameter set to true", () => {
+      return getCompleteTable({
+        pimUrl: SERVER_URL
+      }, 3, 2, true).then(result => {
+        expect(calledUrls.some(elem => /\/tables\/3\/rows\?offset=0&limit=2/.test(elem))).to.be.true();
+
+        expect(result).to.have.property("id");
+        expect(result.name).to.equal("thirdTestTable");
+        expect(result).to.have.property("rows");
+        expect(result.rows).to.be.an.array();
+      });
+    });
+
+    it("should construct the correct URL for the rows API call with includeArchived parameter set to false", () => {
+      return getCompleteTable({
+        pimUrl: SERVER_URL
+      }, 3, 2, false).then(result => {
+        // Check if the correct URL was called
+        expect(calledUrls.some(elem => /\/tables\/3\/rows\?offset=0&limit=2&archived=false/.test(elem))).to.be.true();
+
+        expect(result).to.have.property("id");
+        expect(result.name).to.equal("thirdTestTable");
+        expect(result).to.have.property("rows");
+        expect(result.rows).to.be.an.array();
       });
     });
 


### PR DESCRIPTION
Mit diesem PR wird die `getEntitiesOfTable` Funktion um die Option `includeArchived` erweitert.

Durch diese neue Option besteht die Möglichkeit archivierten Datensätze der GRUD aus der Rückgabe der `getEntitiesOfTable` Funktion herauszufiltern. 

Dazu wird der GRUD Endpunkt /tables/{tableID}/rows mit dem passenden query genutzt.

Die Möglichkeit nur archivierte Datensätze zurückzugeben, also alle nicht archivierten herauszufiltern, wurde erstmal nicht berücksichtigt.