### PR TITLE
feat: added timeout option for requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,11 @@
 
 ## 8.6.0 - Extended `getEntitiesOfTable()` function by `timeout` option
 
-* The default internal timeout for requests is now set to 2 minutes (120000 milliseconds). This can be overridden by
-  the `timeout` option.
-* `timeout: Number` option has been added for `getEntitiesOfTable()`. If set, it will limit the time in milliseconds
-  for the request to GRUD. If the request takes longer than this time, it will be aborted and an error will be thrown.
+* `timeout: Number` option has been added for `getEntitiesOfTable()`. Default is 120000 milliseconds (2 minutes).
+  The timeout limits the time for the request to GRUD. If the request takes longer than this time,
+  it will be aborted and an error will be thrown.
 * `timeout: Number` option has also been added for the API functions `getAllTables()`, `getTablesByNames()`,
-  and `getCompleteTable()`.
-  It works the same way as described above.
+  and `getCompleteTable()`. It works the same way as described above.
 
 ## 8.5.0 - Extended `getEntitiesOfTable()` function by `archived` option
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## 8.6.0 - Extended `getEntitiesOfTable()` function by `timeout` option
+
+* The default internal timeout for requests is now set to 2 minutes (120000 milliseconds). This can be overridden by
+  the `timeout` option.
+* `timeout: Number` option has been added for `getEntitiesOfTable()`. If set, it will limit the time in milliseconds
+  for the request to GRUD. If the request takes longer than this time, it will be aborted and an error will be thrown.
+* `timeout: Number` option has also been added for the API functions `getAllTables()`, `getTablesByNames()`,
+  and `getCompleteTable()`.
+  It works the same way as described above.
+
 ## 8.5.0 - Extended `getEntitiesOfTable()` function by `archived` option
 
 * `archived: Boolean` option has been added for `getEntitiesOfTable()`. If set to `false` archived GRUD rows will get omitted. If set to `true`, 

--- a/lib/entities.js
+++ b/lib/entities.js
@@ -35,7 +35,8 @@ function getEntitiesOfTable(tableNameOrNames) {
       maxEntriesPerRequest = _options$maxEntriesPe === void 0 ? 500 : _options$maxEntriesPe,
       archived = options.archived,
       _options$headers = options.headers,
-      headers = _options$headers === void 0 ? {} : _options$headers;
+      headers = _options$headers === void 0 ? {} : _options$headers,
+      timeout = options.timeout;
 
   if (_lodash.default.isNil(pimUrl)) {
     throw new Error("Missing option pimUrl");
@@ -71,6 +72,10 @@ function getEntitiesOfTable(tableNameOrNames) {
     throw new Error("Expecting headers to be an object of key value pairs (string:string)");
   }
 
+  if (!_lodash.default.isNil(timeout) && !_lodash.default.isInteger(timeout)) {
+    throw new Error("Expecting timeout to be an integer representing milliseconds");
+  }
+
   var promises = {};
   var tables = {};
 
@@ -78,7 +83,8 @@ function getEntitiesOfTable(tableNameOrNames) {
 
   return _pimApi.getTablesByNames.apply(void 0, [{
     pimUrl: pimUrl,
-    headers: headers
+    headers: headers,
+    timeout: timeout
   }].concat(_toConsumableArray(tableNames))).then(function (tablesFromPim) {
     return _lodash.default.reduce(tablesFromPim, function (accumulatorPromise, table) {
       return accumulatorPromise.then(function () {
@@ -97,7 +103,8 @@ function getEntitiesOfTable(tableNameOrNames) {
     if (!promises[tableId]) {
       var promiseOfLinkedTables = (0, _pimApi.getCompleteTable)({
         pimUrl: pimUrl,
-        headers: headers
+        headers: headers,
+        timeout: timeout
       }, tableId, maxEntriesPerRequest, archived).then(function (table) {
         tables[tableId] = table;
 

--- a/lib/entities.js
+++ b/lib/entities.js
@@ -36,7 +36,8 @@ function getEntitiesOfTable(tableNameOrNames) {
       archived = options.archived,
       _options$headers = options.headers,
       headers = _options$headers === void 0 ? {} : _options$headers,
-      timeout = options.timeout;
+      _options$timeout = options.timeout,
+      timeout = _options$timeout === void 0 ? 120000 : _options$timeout;
 
   if (_lodash.default.isNil(pimUrl)) {
     throw new Error("Missing option pimUrl");

--- a/lib/entities.js
+++ b/lib/entities.js
@@ -86,7 +86,11 @@ function getEntitiesOfTable(tableNameOrNames) {
       });
     }, Promise.resolve([]));
   }).then(function () {
-    return mapRowsOfTables(tables);
+    _lodash.default.each(tables, function (table) {
+      table.rows = _lodash.default.keyBy(table.rows, "id");
+    });
+
+    return tables;
   });
 
   function getTableAndLinkedTablesAsPromise(tableId, disableFollow, maxEntriesPerRequest, archived, includeColumns) {
@@ -134,14 +138,4 @@ function getEntitiesOfTable(tableNameOrNames) {
 
     return disabledColumns.includes(columnName);
   }
-}
-
-function mapRowsOfTables(tables) {
-  return _lodash.default.mapValues(tables, function (table) {
-    var mappedTable = table;
-    mappedTable.rows = _lodash.default.transform(table.rows, function (acc, row) {
-      acc[row.id] = row;
-    }, {});
-    return mappedTable;
-  });
 }

--- a/lib/pimApi.js
+++ b/lib/pimApi.js
@@ -30,11 +30,12 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
 function getAllTables(options) {
   var _getOptionsFromParam = getOptionsFromParam(options, "getAllTables"),
       pimUrl = _getOptionsFromParam.pimUrl,
-      _getOptionsFromParam$ = _getOptionsFromParam.headers,
-      headers = _getOptionsFromParam$ === void 0 ? {} : _getOptionsFromParam$;
+      headers = _getOptionsFromParam.headers,
+      timeout = _getOptionsFromParam.timeout;
 
   return request("GET", "".concat(pimUrl, "/tables"), {
-    headers: headers
+    headers: headers,
+    timeout: timeout
   }).then(function (data) {
     return data.tables;
   });
@@ -57,8 +58,8 @@ function getTablesByNames(options) {
 function getCompleteTable(options, tableId, maxEntries, archived) {
   var _getOptionsFromParam2 = getOptionsFromParam(options, "getAllTables"),
       pimUrl = _getOptionsFromParam2.pimUrl,
-      _getOptionsFromParam3 = _getOptionsFromParam2.headers,
-      headers = _getOptionsFromParam3 === void 0 ? {} : _getOptionsFromParam3;
+      headers = _getOptionsFromParam2.headers,
+      timeout = _getOptionsFromParam2.timeout;
 
   if (!_lodash.default.isInteger(tableId) || tableId < 0) {
     throw new Error("Expecting tableId to be a positive integer greater than or equal 0");
@@ -73,12 +74,14 @@ function getCompleteTable(options, tableId, maxEntries, archived) {
   }
 
   return request("GET", "".concat(pimUrl, "/tables/").concat(tableId), {
-    headers: headers
+    headers: headers,
+    timeout: timeout
   }).then(function (table) {
     var tableWithoutMeta = _lodash.default.omit(table, ["status"]);
 
     return request("GET", "".concat(pimUrl, "/tables/").concat(tableId, "/columns"), {
-      headers: headers
+      headers: headers,
+      timeout: timeout
     }).then(function (result) {
       return _objectSpread({}, tableWithoutMeta, {
         columns: result.columns
@@ -91,7 +94,8 @@ function getCompleteTable(options, tableId, maxEntries, archived) {
     });
     var url = "".concat(pimUrl, "/tables/").concat(tableId, "/rows?").concat(queryString);
     return request("GET", url, {
-      headers: headers
+      headers: headers,
+      timeout: timeout
     }).then(function (result) {
       var totalSize = result.page.totalSize;
       var elements = Math.ceil(totalSize / maxEntries);
@@ -99,7 +103,8 @@ function getCompleteTable(options, tableId, maxEntries, archived) {
       return requests.reduce(function (promise, requestUrl) {
         return promise.then(function (tableColumnsAndRows) {
           return request("GET", requestUrl, {
-            headers: headers
+            headers: headers,
+            timeout: timeout
           }).then(function (rowResult) {
             return _objectSpread({}, tableColumnsAndRows, {
               rows: tableColumnsAndRows.rows.concat(rowResult.rows)
@@ -168,12 +173,14 @@ function generateQueryString(_ref) {
   }).join("&");
 }
 
-function request(method, url, options) {
-  var headers = options.headers;
+function request(method, url, _ref4) {
+  var headers = _ref4.headers,
+      timeout = _ref4.timeout;
   return (0, _axios.default)({
     method: method,
     url: url,
-    headers: headers
+    headers: headers,
+    timeout: timeout || 120000
   }).then(function (res) {
     return res.data;
   });

--- a/lib/pimApi.js
+++ b/lib/pimApi.js
@@ -180,7 +180,7 @@ function request(method, url, _ref4) {
     method: method,
     url: url,
     headers: headers,
-    timeout: timeout || 120000
+    timeout: timeout
   }).then(function (res) {
     return res.data;
   });

--- a/src/entities.js
+++ b/src/entities.js
@@ -13,7 +13,7 @@ export function getEntitiesOfTable(tableNameOrNames, options = {}) {
     maxEntriesPerRequest = 500,
     archived,
     headers = {},
-    timeout
+    timeout = 120000 // 2 minutes
   } = options;
 
   if (_.isNil(pimUrl)) {

--- a/src/entities.js
+++ b/src/entities.js
@@ -46,7 +46,13 @@ export function getEntitiesOfTable(tableNameOrNames, options = {}) {
         getTableAndLinkedTablesAsPromise(table.id, disableFollow, maxEntriesPerRequest, archived, includeColumns)
       );
     }, Promise.resolve([])))
-    .then(() => mapRowsOfTables(tables));
+    .then(() => {
+      _.each(tables, table => {
+        table.rows = _.keyBy(table.rows, "id");
+      });
+
+      return tables;
+    });
 
   function getTableAndLinkedTablesAsPromise(tableId, disableFollow, maxEntriesPerRequest, archived, includeColumns) {
     if (!promises[tableId]) {
@@ -91,14 +97,4 @@ export function getEntitiesOfTable(tableNameOrNames, options = {}) {
 
     return disabledColumns.includes(columnName);
   }
-}
-
-function mapRowsOfTables(tables) {
-  return _.mapValues(tables, table => {
-    const mappedTable = table;
-    mappedTable.rows = _.transform(table.rows, (acc, row) => {
-      acc[row.id] = row;
-    }, {});
-    return mappedTable;
-  });
 }

--- a/src/entities.js
+++ b/src/entities.js
@@ -6,7 +6,15 @@ export function getEntitiesOfTables(tableNames, options = {}) {
 }
 
 export function getEntitiesOfTable(tableNameOrNames, options = {}) {
-  const {disableFollow = [], includeColumns, pimUrl, maxEntriesPerRequest = 500, archived, headers = {}} = options;
+  const {
+    disableFollow = [],
+    includeColumns,
+    pimUrl,
+    maxEntriesPerRequest = 500,
+    archived,
+    headers = {},
+    timeout
+  } = options;
 
   if (_.isNil(pimUrl)) {
     throw new Error("Missing option pimUrl");
@@ -36,11 +44,15 @@ export function getEntitiesOfTable(tableNameOrNames, options = {}) {
     throw new Error("Expecting headers to be an object of key value pairs (string:string)");
   }
 
+  if (!_.isNil(timeout) && !_.isInteger(timeout)) {
+    throw new Error("Expecting timeout to be an integer representing milliseconds");
+  }
+
   const promises = {};
   const tables = {};
   const tableNames = _.concat(tableNameOrNames);
 
-  return getTablesByNames({pimUrl, headers}, ...tableNames)
+  return getTablesByNames({pimUrl, headers, timeout}, ...tableNames)
     .then(tablesFromPim => _.reduce(tablesFromPim, (accumulatorPromise, table) => {
       return accumulatorPromise.then(() =>
         getTableAndLinkedTablesAsPromise(table.id, disableFollow, maxEntriesPerRequest, archived, includeColumns)
@@ -56,7 +68,7 @@ export function getEntitiesOfTable(tableNameOrNames, options = {}) {
 
   function getTableAndLinkedTablesAsPromise(tableId, disableFollow, maxEntriesPerRequest, archived, includeColumns) {
     if (!promises[tableId]) {
-      const promiseOfLinkedTables = getCompleteTable({pimUrl, headers}, tableId, maxEntriesPerRequest, archived)
+      const promiseOfLinkedTables = getCompleteTable({pimUrl, headers, timeout}, tableId, maxEntriesPerRequest, archived)
         .then(table => {
           tables[tableId] = table;
 

--- a/src/pimApi.js
+++ b/src/pimApi.js
@@ -109,7 +109,7 @@ function request(method, url, {headers, timeout}) {
     method,
     url,
     headers,
-    timeout: timeout || 120000
+    timeout
   })
     .then(res => res.data);
 }

--- a/src/pimApi.spec.js
+++ b/src/pimApi.spec.js
@@ -157,6 +157,17 @@ describe("pimApi", () => {
         expect(result[1].name).to.equal("anotherTestTable");
       });
     });
+
+    it("should timeout after number of milliseconds specified in options", () => {
+      const TIMEOUT_MS = 100;
+
+      process.env.FORCE_DELAY_MS = 1000;
+
+      return getTablesByNames({
+        pimUrl: SERVER_URL,
+        timeout: TIMEOUT_MS
+      }, "testTable", "anotherTestTable").must.reject.with.error(new RegExp(`timeout.+${TIMEOUT_MS}ms`, "i"));
+    });
   });
 
   describe("getCompleteTable", () => {

--- a/src/pimApi.spec.js
+++ b/src/pimApi.spec.js
@@ -7,6 +7,7 @@ describe("pimApi", () => {
 
   const TEST_PORT = 14432;
   const SERVER_URL = `http://localhost:${TEST_PORT}`;
+
   let server;
   let calledUrls;
   let headers;
@@ -17,26 +18,37 @@ describe("pimApi", () => {
       app.use((req, res) => {
         calledUrls.push(req.url);
         headers = req.headers;
+
+        const sendFile = (fileName) => {
+          if (process.env.FORCE_DELAY_MS) {
+            setTimeout(() => {
+              res.sendFile(fileName);
+            }, process.env.FORCE_DELAY_MS);
+          } else {
+            res.sendFile(fileName);
+          }
+        };
+
         if (req.url === "/tables") {
-          res.sendFile(`${__dirname}/__tests__/pimFixture-alltables.json`);
+          sendFile(`${__dirname}/__tests__/pimFixture-alltables.json`);
         } else if (req.url === "/tables/1") {
-          res.sendFile(`${__dirname}/__tests__/pimFixture-1-table.json`);
+          sendFile(`${__dirname}/__tests__/pimFixture-1-table.json`);
         } else if (req.url === "/tables/3") {
-          res.sendFile(`${__dirname}/__tests__/pimFixture-3-table.json`);
+          sendFile(`${__dirname}/__tests__/pimFixture-3-table.json`);
         } else if (req.url === "/tables/3/columns") {
-          res.sendFile(`${__dirname}/__tests__/pimFixture-3-columns.json`);
+          sendFile(`${__dirname}/__tests__/pimFixture-3-columns.json`);
         } else if (req.url === "/tables/1/rows?offset=0&limit=500") {
-          res.sendFile(`${__dirname}/__tests__/pimFixture-1-rows500.json`);
+          sendFile(`${__dirname}/__tests__/pimFixture-1-rows500.json`);
         } else if (req.url === "/tables/3/rows?offset=0&limit=2") {
-          res.sendFile(`${__dirname}/__tests__/pimFixture-3-rows1.json`);
+          sendFile(`${__dirname}/__tests__/pimFixture-3-rows1.json`);
         } else if (req.url === "/tables/3/rows?offset=2&limit=2") {
-          res.sendFile(`${__dirname}/__tests__/pimFixture-3-rows2.json`);
+          sendFile(`${__dirname}/__tests__/pimFixture-3-rows2.json`);
         } else if (req.url === "/tables/3/rows?offset=4&limit=2") {
-          res.sendFile(`${__dirname}/__tests__/pimFixture-3-rows3.json`);
+          sendFile(`${__dirname}/__tests__/pimFixture-3-rows3.json`);
         } else if (req.url === "/tables/3/rows?offset=0&limit=2&archived=true") {
-          res.sendFile(`${__dirname}/__tests__/pimFixture-3-rows3.json`);
+          sendFile(`${__dirname}/__tests__/pimFixture-3-rows3.json`);
         } else if (req.url === "/tables/3/rows?offset=0&limit=2&archived=false") {
-          res.sendFile(`${__dirname}/__tests__/pimFixture-3-rows3.json`);
+          sendFile(`${__dirname}/__tests__/pimFixture-3-rows3.json`);
         } else {
           res.end("error");
         }
@@ -52,6 +64,8 @@ describe("pimApi", () => {
   });
 
   beforeEach(() => {
+    process.env.FORCE_DELAY_MS = null;
+
     calledUrls = [];
     headers = {};
   });
@@ -86,6 +100,17 @@ describe("pimApi", () => {
         expect(headers).to.have.property("test");
         expect(headers.test).to.equal("test");
       });
+    });
+
+    it("should timeout after number of milliseconds specified in options", () => {
+      const TIMEOUT_MS = 100;
+
+      process.env.FORCE_DELAY_MS = 1000;
+
+      return getAllTables({
+        pimUrl: SERVER_URL,
+        timeout: TIMEOUT_MS
+      }).must.reject.with.error(new RegExp(`timeout.+${TIMEOUT_MS}ms`, "i"));
     });
   });
 
@@ -219,6 +244,16 @@ describe("pimApi", () => {
       });
     });
 
+    it("should timeout after number of milliseconds specified in options", () => {
+      const TIMEOUT_MS = 100;
+
+      process.env.FORCE_DELAY_MS = 1000;
+
+      return getCompleteTable({
+        pimUrl: SERVER_URL,
+        timeout: TIMEOUT_MS
+      }, 3, 2, false).must.reject.with.error(new RegExp(`timeout.+${TIMEOUT_MS}ms`, "i"));
+    });
   });
 
 });


### PR DESCRIPTION
Axios hat standardmäßig einen Timeout von 0 für die Requests (= unendlich). Mit dieser Erweiterung soll es möglich sein, einen optionalen Parameter `timeout` an `getEntitiesOfTable()` und die API Funktionen mitzugeben.