### PR TITLE
GRUD_DEV-1186/add possibility to cancel running exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## 9.1.0 - Added cancellation support for `start() function`
+
+* Added `signal` option to `start()` accepting an `AbortSignal`. Aborting the signal terminates the forked aggregator
+  process (`SIGTERM`) and rejects the returned promise with the signal's `reason`. If the signal is already aborted when
+  `start` is called, the promise rejects immediately and no child process is spawned.
+* Added `abortGracePeriod` option (defaults to `1000` ms). After `SIGTERM`, the parent waits this long before escalating
+  to `SIGKILL`, giving the aggregator time to clean up (e.g. flushing database transactions or in-flight uploads).
+
 ## 9.0.0 - Convert to ES-Module
 
 * Replaced `@babel/core` with `tsdown`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 ## 9.1.0 - Added cancellation support for `start() function`
 
-* Added `signal` option to `start()` accepting an `AbortSignal`. Aborting the signal terminates the forked aggregator
-  process (`SIGTERM`) and rejects the returned promise with the signal's `reason`. If the signal is already aborted when
-  `start` is called, the promise rejects immediately and no child process is spawned.
-* Added `abortGracePeriod` option (defaults to `1000` ms). After `SIGTERM`, the parent waits this long before escalating
-  to `SIGKILL`, giving the aggregator time to clean up (e.g. flushing database transactions or in-flight uploads).
+* Added `abort` option to `start()` that groups the new cancellation-related settings in a dedicated object. This keeps
+  their key names out of the rest-parameter namespace that is forwarded as `options` to the aggregator, so existing
+  callers remain unaffected.
+  * `abort.signal` (`AbortSignal`): Aborting the signal terminates the forked aggregator process (`SIGTERM`) and rejects
+    the returned promise with the signal's `reason`. If the signal is already aborted when `start` is called, the
+    promise rejects immediately and no child process is spawned.
+  * `abort.abortGracePeriod` (number, defaults to `1000` ms): After `SIGTERM`, the parent waits this long before
+    escalating to `SIGKILL`, giving the aggregator time to clean up (e.g. flushing database transactions or in-flight
+    uploads).
 
 ## 9.0.0 - Convert to ES-Module
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ export default function start(step, progress, options) {
 }
 ```
 
-#### `start({ aggregatorFile, progress, timeoutToResendStatus, signal, abortGracePeriod[, ...other options] })`
+#### `start({ aggregatorFile, progress, timeoutToResendStatus, abort[, ...other options] })`
 
 * `aggregatorFile` (`string`, required) is the file that should be spawn into a process. It consists of an exported
   default function `start(step, progress[, options])`, which will be called with these parameters:
@@ -60,13 +60,15 @@ export default function start(step, progress, options) {
 * `timeoutToResendStatus` (number, defaults to `2000`) is a number in milliseconds when the aggregator should resend the
   latest status to the `progress` function. This helps to prevent the closing of a channel if an aggregator takes too 
   long to respond with a new progress.
-* `signal` (`AbortSignal`, optional) - If provided, aborting the signal will terminate the forked aggregator process
-  (`SIGTERM`) and reject the returned promise with the signal's `reason`. If the signal is already aborted when `start`
-  is called, the promise rejects immediately and no child process is spawned. The `signal` itself is not forwarded to
-  the aggregator script.
-* `abortGracePeriod` (number, defaults to `1000`) - Milliseconds to wait after `SIGTERM` before escalating to `SIGKILL`
-  when an abort is requested. Increase this if your aggregator needs more time to clean up (e.g. flushing open database
-  transactions or finishing in-flight uploads). Ignored when no `signal` is provided.
+* `abort` (object, optional) - Groups the cancellation-related options. Kept as a separate object so that its keys never
+  collide with arbitrary aggregator options passed via `...other options`.
+  * `abort.signal` (`AbortSignal`, optional) - If provided, aborting the signal will terminate the forked aggregator
+    process (`SIGTERM`) and reject the returned promise with the signal's `reason`. If the signal is already aborted
+    when `start` is called, the promise rejects immediately and no child process is spawned. The `signal` itself is not
+    forwarded to the aggregator script.
+  * `abort.abortGracePeriod` (number, defaults to `1000`) - Milliseconds to wait after `SIGTERM` before escalating to
+    `SIGKILL` when an abort is requested. Increase this if your aggregator needs more time to clean up (e.g. flushing
+    open database transactions or finishing in-flight uploads). Ignored when no `abort.signal` is provided.
 * All other keys in the argument passed to start will be sent to the newly spawned aggregation process. The options will
   be serialized to JSON and back, therefore it is not possible to pass functions.
 
@@ -74,7 +76,7 @@ Example:
 
 ```javascript
 const controller = new AbortController();
-const promise = start({aggregatorFile: "./myAggregator.js", signal: controller.signal});
+const promise = start({aggregatorFile: "./myAggregator.js", abort: {signal: controller.signal}});
 // later, e.g. on user request:
 controller.abort(new Error("cancelled by user"));
 ```

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ export default function start(step, progress, options) {
     forwarded to the aggregator script.
   * `abort.abortGracePeriod` (number, defaults to `1000`) - Milliseconds to wait after `SIGTERM` before escalating to
     `SIGKILL` when an abort is requested. Increase this if your aggregator needs more time to clean up (e.g. flushing
-    open database transactions or finishing in-flight uploads). Ignored when no `abort.signal` is provided.
+    open database transactions or finishing in-flight uploads). Only takes effect when `abort.signal` is provided, but is always validated to catch typos.
 * All other keys in the argument passed to start will be sent to the newly spawned aggregation process. The options will
   be serialized to JSON and back, therefore it is not possible to pass functions.
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ export default function start(step, progress, options) {
   the aggregator script.
 * `abortGracePeriod` (number, defaults to `1000`) - Milliseconds to wait after `SIGTERM` before escalating to `SIGKILL`
   when an abort is requested. Increase this if your aggregator needs more time to clean up (e.g. flushing open database
-  transactions or finishing in-flight uploads). Set to `0` to kill immediately. Ignored when no `signal` is provided.
+  transactions or finishing in-flight uploads). Ignored when no `signal` is provided.
 * All other keys in the argument passed to start will be sent to the newly spawned aggregation process. The options will
   be serialized to JSON and back, therefore it is not possible to pass functions.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ export default function start(step, progress, options) {
 }
 ```
 
-#### `start({ aggregatorFile, progress, timeoutToResendStatus[, ...other options] })`
+#### `start({ aggregatorFile, progress, timeoutToResendStatus, signal, abortGracePeriod[, ...other options] })`
 
 * `aggregatorFile` (`string`, required) is the file that should be spawn into a process. It consists of an exported
   default function `start(step, progress[, options])`, which will be called with these parameters:
@@ -60,8 +60,24 @@ export default function start(step, progress, options) {
 * `timeoutToResendStatus` (number, defaults to `2000`) is a number in milliseconds when the aggregator should resend the
   latest status to the `progress` function. This helps to prevent the closing of a channel if an aggregator takes too 
   long to respond with a new progress.
+* `signal` (`AbortSignal`, optional) - If provided, aborting the signal will terminate the forked aggregator process
+  (`SIGTERM`) and reject the returned promise with the signal's `reason`. If the signal is already aborted when `start`
+  is called, the promise rejects immediately and no child process is spawned. The `signal` itself is not forwarded to
+  the aggregator script.
+* `abortGracePeriod` (number, defaults to `1000`) - Milliseconds to wait after `SIGTERM` before escalating to `SIGKILL`
+  when an abort is requested. Increase this if your aggregator needs more time to clean up (e.g. flushing open database
+  transactions or finishing in-flight uploads). Set to `0` to kill immediately. Ignored when no `signal` is provided.
 * All other keys in the argument passed to start will be sent to the newly spawned aggregation process. The options will
   be serialized to JSON and back, therefore it is not possible to pass functions.
+
+Example:
+
+```javascript
+const controller = new AbortController();
+const promise = start({aggregatorFile: "./myAggregator.js", signal: controller.signal});
+// later, e.g. on user request:
+controller.abort(new Error("cancelled by user"));
+```
 
 #### `getEntitiesOfTable(tableName, options): Promise[GrudTables]`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grud-aggregator",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "description": "Core aggregator functions",
   "files": [
     "dist"

--- a/src/__tests__/aggregatorDoneThenWait.js
+++ b/src/__tests__/aggregatorDoneThenWait.js
@@ -1,0 +1,6 @@
+export default function start(step) {
+  return Promise
+    .resolve()
+    .then(step("done soon"))
+    .then(() => "finished");
+}

--- a/src/__tests__/aggregatorEchoOptions.js
+++ b/src/__tests__/aggregatorEchoOptions.js
@@ -1,0 +1,6 @@
+export default function start(step, progress, options) {
+  return Promise
+    .resolve()
+    .then(step("echoing options"))
+    .then(() => options);
+}

--- a/src/__tests__/aggregatorIgnoreSigterm.js
+++ b/src/__tests__/aggregatorIgnoreSigterm.js
@@ -1,0 +1,10 @@
+export default function start(step) {
+  process.on("SIGTERM", () => {
+    // Intentionally ignored to verify the parent escalates to SIGKILL.
+  });
+
+  return Promise
+    .resolve()
+    .then(step(`${process.pid}`))
+    .then(() => new Promise(() => {}));
+}

--- a/src/aggregationProcess.js
+++ b/src/aggregationProcess.js
@@ -147,6 +147,9 @@ export function start(
         if (progress) {
           progress(payload);
         }
+        if (aborted || fulfilled) {
+          return;
+        }
         resendProgressTimerId = setTimeout(() => {
           sendProgress(payload);
         }, timeoutToResendStatus);

--- a/src/aggregationProcess.js
+++ b/src/aggregationProcess.js
@@ -20,9 +20,9 @@ export function start(
   }
 
   if (!_.isNil(signal) && (
-    typeof signal.addEventListener !== "function" ||
-    typeof signal.removeEventListener !== "function" ||
-    typeof signal.aborted !== "boolean"
+    typeof signal.addEventListener !== "function"
+    || typeof signal.removeEventListener !== "function"
+    || typeof signal.aborted !== "boolean"
   )) {
     throw new Error("Expects AbortSignal for optional `signal` parameter");
   }

--- a/src/aggregationProcess.js
+++ b/src/aggregationProcess.js
@@ -6,8 +6,7 @@ export function start(
     aggregatorFile,
     progress,
     timeoutToResendStatus = 2000,
-    signal,
-    abortGracePeriod = 1000,
+    abort: { signal, abortGracePeriod = 1000 } = {},
     ...rest
   } = {}) {
 
@@ -24,11 +23,11 @@ export function start(
     || typeof signal.removeEventListener !== "function"
     || typeof signal.aborted !== "boolean"
   )) {
-    throw new Error("Expects AbortSignal for optional `signal` parameter");
+    throw new Error("Expects AbortSignal for optional `abort.signal` parameter");
   }
 
   if (!_.isFinite(abortGracePeriod) || abortGracePeriod < 0) {
-    throw new Error("Expects non-negative number for optional `abortGracePeriod` parameter");
+    throw new Error("Expects non-negative number for optional `abort.abortGracePeriod` parameter");
   }
 
   // prevent esm/cjs mismatch

--- a/src/aggregationProcess.js
+++ b/src/aggregationProcess.js
@@ -6,6 +6,8 @@ export function start(
     aggregatorFile,
     progress,
     timeoutToResendStatus = 2000,
+    signal,
+    abortGracePeriod = 1000,
     ...rest
   } = {}) {
 
@@ -17,6 +19,18 @@ export function start(
     throw new Error("Expects function for optional `progress` parameter");
   }
 
+  if (!_.isNil(signal) && (
+    typeof signal.addEventListener !== "function" ||
+    typeof signal.removeEventListener !== "function" ||
+    typeof signal.aborted !== "boolean"
+  )) {
+    throw new Error("Expects AbortSignal for optional `signal` parameter");
+  }
+
+  if (!_.isFinite(abortGracePeriod) || abortGracePeriod < 0) {
+    throw new Error("Expects non-negative number for optional `abortGracePeriod` parameter");
+  }
+
   // prevent esm/cjs mismatch
   // esm has to fork esm and cjs has to fork cjs
   const extension = import.meta.filename.endsWith(".cjs") ? ".cjs" : ".js";
@@ -24,15 +38,67 @@ export function start(
   return Promise
     .resolve()
     .then(() => new Promise((resolve, reject) => {
+      if (signal && signal.aborted) {
+        reject(signal.reason ?? new Error("Aggregator aborted"));
+        return;
+      }
+
       const child = cp.fork(`${import.meta.dirname}/forker${extension}`, {silent: false});
+
       let initialized = false;
       let fulfilled = false;
       let allDone = false;
+      let doneReceived = false;
+      let aborted = false;
+      let abortReason;
       let allSteps = 0;
       let resendProgressTimerId = null;
+      let abortKillTimerId = null;
       let result;
 
-      child.on("message", ({action, payload, data}) => {
+      const clearResendProgressTimer = () => {
+        if (resendProgressTimerId !== null) {
+          clearTimeout(resendProgressTimerId);
+          resendProgressTimerId = null;
+        }
+      };
+
+      const clearAbortKillTimer = () => {
+        if (abortKillTimerId !== null) {
+          clearTimeout(abortKillTimerId);
+          abortKillTimerId = null;
+        }
+      };
+
+      const onAbort = () => {
+        if (fulfilled || doneReceived) {
+          return;
+        }
+
+        aborted = true;
+        abortReason = signal.reason ?? new Error("Aggregator aborted");
+
+        clearResendProgressTimer();
+        child.kill("SIGTERM");
+
+        abortKillTimerId = setTimeout(() => {
+          if (!fulfilled) {
+            child.kill("SIGKILL");
+          }
+        }, abortGracePeriod);
+      };
+
+      if (signal) {
+        signal.addEventListener("abort", onAbort, { once: true });
+      }
+
+      const removeAbortListener = () => {
+        if (signal) {
+          signal.removeEventListener("abort", onAbort);
+        }
+      };
+
+      child.on("message", ({ action, payload, data }) => {
         if (action === "INIT") {
           initialized = true;
           allSteps = payload.stepsInAggregator;
@@ -44,13 +110,12 @@ export function start(
         } else if (action === "PROGRESS") {
           sendProgress(payload);
         } else if (action === "DONE") {
-          sendProgress(payload);
-          if (resendProgressTimerId !== null) {
-            clearTimeout(resendProgressTimerId);
-            resendProgressTimerId = null;
-          }
+          doneReceived = true;
+          removeAbortListener();
           allDone = true;
           result = data;
+          sendProgress(payload);
+          clearResendProgressTimer();
           child.kill();
         }
       });
@@ -60,6 +125,9 @@ export function start(
       child.on("error", err => {
         if (!fulfilled) {
           fulfilled = true;
+          clearResendProgressTimer();
+          clearAbortKillTimer();
+          removeAbortListener();
           console.log(`Aggregator broke due to an uncaught error ${err.message}`);
           reject(err);
         }
@@ -76,9 +144,7 @@ export function start(
       });
 
       function sendProgress(payload) {
-        if (resendProgressTimerId !== null) {
-          clearTimeout(resendProgressTimerId);
-        }
+        clearResendProgressTimer();
         if (progress) {
           progress(payload);
         }
@@ -87,24 +153,27 @@ export function start(
         }, timeoutToResendStatus);
       }
 
-      function fulfill(code, signal) {
-        if (resendProgressTimerId !== null) {
-          clearTimeout(resendProgressTimerId);
-        }
+      function fulfill(code, exitSignal) {
+        clearResendProgressTimer();
+        clearAbortKillTimer();
         if (!fulfilled) {
           fulfilled = true;
-          if (allDone) {
-            resolve({result});
+          removeAbortListener();
+
+          if (aborted) {
+            reject(abortReason);
+          } else if (allDone) {
+            resolve({ result });
           } else if (!initialized) {
             reject(
               new Error(`Could not start up aggregator ${aggregatorFile}. Correct path? Uncaught exception in init?`)
             );
-          } else if (signal !== null) {
-            reject(new Error(`Aggregator got killed with signal ${signal}`));
+          } else if (exitSignal !== null) {
+            reject(new Error(`Aggregator got killed with signal ${exitSignal}`));
           } else if (code !== 0) {
             reject(new Error(`Aggregator broke, possible uncaught exception. Exit code ${code}`));
           } else {
-            resolve({result, code, signal});
+            resolve({ result, code, signal: exitSignal });
           }
         }
       }

--- a/src/aggregationProcess.spec.js
+++ b/src/aggregationProcess.spec.js
@@ -9,6 +9,8 @@ describe("aggregation-process", function () {
   const aggregatorBreaking = `${import.meta.dirname}/__tests__/aggregatorBreaking.js`;
   const aggregatorDummy = `${import.meta.dirname}/__tests__/aggregatorDummy.js`;
   const aggregatorDummyWithReplacedAndHiddenMessages = `${import.meta.dirname}/__tests__/aggregatorDummyWithReplacedAndHiddenMessages.js`;
+  const aggregatorDoneThenWait = `${import.meta.dirname}/__tests__/aggregatorDoneThenWait.js`;
+  const aggregatorIgnoreSigterm = `${import.meta.dirname}/__tests__/aggregatorIgnoreSigterm.js`;
   const aggregatorFile = `${import.meta.dirname}/__tests__/aggregatorWorking.js`;
   const aggregatorFileSubsteps = `${import.meta.dirname}/__tests__/aggregatorSubsteps.js`;
   const aggregatorFileSubsteps2 = `${import.meta.dirname}/__tests__/aggregatorSubsteps2.js`;
@@ -251,6 +253,144 @@ describe("aggregation-process", function () {
         })
         .then(() => setTimeout(resolve, 500));
     });
+  });
+
+  describe("AbortSignal support", function () {
+
+    it("throws synchronously on invalid signal without forking", function () {
+      const originalFork = cp.fork;
+      let forkCalled = false;
+
+      cp.fork = (...args) => {
+        forkCalled = true;
+        return originalFork(...args);
+      };
+
+      try {
+        expect(() => start({
+          aggregatorFile: aggregatorDummy,
+          signal: {
+            aborted: false,
+            addEventListener() {}
+          }
+        })).to.throw(/AbortSignal/);
+        expect(forkCalled).to.be.false();
+      } finally {
+        cp.fork = originalFork;
+      }
+    });
+
+    it("rejects immediately if signal is already aborted", function () {
+      const controller = new AbortController();
+      controller.abort(new Error("nope"));
+
+      return start({
+        aggregatorFile: aggregatorLongRunning,
+        signal: controller.signal,
+        howLong: 1000
+      }).then(() => {
+        throw new Error("should not resolve");
+      }, err => {
+        expect(err).to.be.an.error(/nope/);
+      });
+    });
+
+    it("aborts a running aggregator and rejects with the abort reason", function () {
+      this.timeout(5000);
+      const controller = new AbortController();
+
+      const promise = start({
+        aggregatorFile: aggregatorLongRunning,
+        signal: controller.signal,
+        howLong: 3000
+      }).then(() => {
+        throw new Error("should not resolve");
+      }, err => {
+        expect(err).to.be.an.error(/cancelled/);
+      });
+
+      setTimeout(() => controller.abort(new Error("cancelled by user")), 200);
+
+      return promise;
+    });
+
+    it("ignores abort after DONE and still resolves with the result", function () {
+      this.timeout(5000);
+      const controller = new AbortController();
+      const expected = "finished";
+
+      return start({
+        aggregatorFile: aggregatorDoneThenWait,
+        signal: controller.signal,
+        progress: ({message}) => {
+          if (message === "Done.") {
+            controller.abort(new Error("too late"));
+          }
+        }
+      }).then(({result}) => {
+        expect(result).to.eql(expected);
+      });
+    });
+
+    it("works without a signal (backwards compatible)", function () {
+      return start({
+        aggregatorFile: aggregatorDummy
+      }).then(({result}) => {
+        expect(result).to.be.undefined();
+      });
+    });
+
+    it("escalates to SIGKILL if the aggregator ignores SIGTERM", function () {
+      this.timeout(5000);
+      const controller = new AbortController();
+      const startedAt = Date.now();
+
+      return start({
+        aggregatorFile: aggregatorIgnoreSigterm,
+        signal: controller.signal,
+        progress: ({message, currentStep}) => {
+          if (currentStep === 1 && /^\d+$/.test(message)) {
+            controller.abort(new Error("cancelled forcefully"));
+          }
+        }
+      }).then(() => {
+        throw new Error("should not resolve");
+      }, err => {
+        expect(err).to.be.an.error(/cancelled forcefully/);
+        expect(Date.now() - startedAt).to.be.gte(900);
+      });
+    });
+
+    it("respects a custom abortGracePeriod before escalating to SIGKILL", function () {
+      this.timeout(5000);
+      const controller = new AbortController();
+      let abortedAt = 0;
+
+      return start({
+        aggregatorFile: aggregatorIgnoreSigterm,
+        signal: controller.signal,
+        abortGracePeriod: 100,
+        progress: ({message, currentStep}) => {
+          if (currentStep === 1 && /^\d+$/.test(message)) {
+            abortedAt = Date.now();
+            controller.abort(new Error("cancelled forcefully"));
+          }
+        }
+      }).then(() => {
+        throw new Error("should not resolve");
+      }, err => {
+        expect(err).to.be.an.error(/cancelled forcefully/);
+        expect(Date.now() - abortedAt).to.be.lt(900);
+      });
+    });
+
+    it("throws synchronously on invalid abortGracePeriod", function () {
+      expect(() => start({
+        aggregatorFile: aggregatorDummy,
+        abortGracePeriod: -1
+      })).to.throw(/abortGracePeriod/);
+    });
+
   });
 
   // TODO maybe extend and overwrite function prototype for this...? :)

--- a/src/aggregationProcess.spec.js
+++ b/src/aggregationProcess.spec.js
@@ -269,9 +269,11 @@ describe("aggregation-process", function () {
       try {
         expect(() => start({
           aggregatorFile: aggregatorDummy,
-          signal: {
-            aborted: false,
-            addEventListener() {}
+          abort: {
+            signal: {
+              aborted: false,
+              addEventListener() {}
+            }
           }
         })).to.throw(/AbortSignal/);
         expect(forkCalled).to.be.false();
@@ -286,7 +288,7 @@ describe("aggregation-process", function () {
 
       return start({
         aggregatorFile: aggregatorLongRunning,
-        signal: controller.signal,
+        abort: { signal: controller.signal },
         howLong: 1000
       }).then(() => {
         throw new Error("should not resolve");
@@ -301,7 +303,7 @@ describe("aggregation-process", function () {
 
       const promise = start({
         aggregatorFile: aggregatorLongRunning,
-        signal: controller.signal,
+        abort: { signal: controller.signal },
         howLong: 3000
       }).then(() => {
         throw new Error("should not resolve");
@@ -321,7 +323,7 @@ describe("aggregation-process", function () {
 
       return start({
         aggregatorFile: aggregatorDoneThenWait,
-        signal: controller.signal,
+        abort: { signal: controller.signal },
         progress: ({message}) => {
           if (message === "Done.") {
             controller.abort(new Error("too late"));
@@ -347,7 +349,7 @@ describe("aggregation-process", function () {
 
       return start({
         aggregatorFile: aggregatorIgnoreSigterm,
-        signal: controller.signal,
+        abort: { signal: controller.signal },
         progress: ({message, currentStep}) => {
           if (currentStep === 1 && /^\d+$/.test(message)) {
             controller.abort(new Error("cancelled forcefully"));
@@ -368,8 +370,7 @@ describe("aggregation-process", function () {
 
       return start({
         aggregatorFile: aggregatorIgnoreSigterm,
-        signal: controller.signal,
-        abortGracePeriod: 100,
+        abort: { signal: controller.signal, abortGracePeriod: 100 },
         progress: ({message, currentStep}) => {
           if (currentStep === 1 && /^\d+$/.test(message)) {
             abortedAt = Date.now();
@@ -387,7 +388,7 @@ describe("aggregation-process", function () {
     it("throws synchronously on invalid abortGracePeriod", function () {
       expect(() => start({
         aggregatorFile: aggregatorDummy,
-        abortGracePeriod: -1
+        abort: { abortGracePeriod: -1 }
       })).to.throw(/abortGracePeriod/);
     });
 

--- a/src/aggregationProcess.spec.js
+++ b/src/aggregationProcess.spec.js
@@ -402,6 +402,34 @@ describe("aggregation-process", function () {
       })).to.throw(/abortGracePeriod/);
     });
 
+    it("does not call progress again after abort, even with a long grace period", function () {
+      this.timeout(5000);
+      const controller = new AbortController();
+      let progressCallsAfterAbort = 0;
+      let abortFired = false;
+
+      return start({
+        aggregatorFile: aggregatorIgnoreSigterm,
+        timeoutToResendStatus: 50,
+        abort: { signal: controller.signal, abortGracePeriod: 500 },
+        progress: ({message, currentStep}) => {
+          if (abortFired) {
+            progressCallsAfterAbort += 1;
+            return;
+          }
+          if (currentStep === 1 && /^\d+$/.test(message)) {
+            abortFired = true;
+            controller.abort(new Error("cancelled"));
+          }
+        }
+      }).then(() => {
+        throw new Error("should not resolve");
+      }, err => {
+        expect(err).to.be.an.error(/cancelled/);
+        expect(progressCallsAfterAbort).to.equal(0);
+      });
+    });
+
   });
 
   // TODO maybe extend and overwrite function prototype for this...? :)

--- a/src/aggregationProcess.spec.js
+++ b/src/aggregationProcess.spec.js
@@ -11,6 +11,7 @@ describe("aggregation-process", function () {
   const aggregatorDummyWithReplacedAndHiddenMessages = `${import.meta.dirname}/__tests__/aggregatorDummyWithReplacedAndHiddenMessages.js`;
   const aggregatorDoneThenWait = `${import.meta.dirname}/__tests__/aggregatorDoneThenWait.js`;
   const aggregatorIgnoreSigterm = `${import.meta.dirname}/__tests__/aggregatorIgnoreSigterm.js`;
+  const aggregatorEchoOptions = `${import.meta.dirname}/__tests__/aggregatorEchoOptions.js`;
   const aggregatorFile = `${import.meta.dirname}/__tests__/aggregatorWorking.js`;
   const aggregatorFileSubsteps = `${import.meta.dirname}/__tests__/aggregatorSubsteps.js`;
   const aggregatorFileSubsteps2 = `${import.meta.dirname}/__tests__/aggregatorSubsteps2.js`;
@@ -339,6 +340,15 @@ describe("aggregation-process", function () {
         aggregatorFile: aggregatorDummy
       }).then(({result}) => {
         expect(result).to.be.undefined();
+      });
+    });
+
+    it("works with custom aggregator options (backwards compatible)", function () {
+      return start({
+        aggregatorFile: aggregatorEchoOptions,
+        foo: "bar"
+      }).then(({result}) => {
+        expect(result).to.eql({ foo: "bar" });
       });
     });
 


### PR DESCRIPTION
PR für den Task: https://campudus.myjetbrains.com/youtrack/agiles/112-23/current?issue=GRUD_DEV-1186

Fügt Abbruch-Unterstützung zu `start()` hinzu:

- Neue Option `signal: AbortSignal` — beim Abbrechen wird `SIGTERM` an den geforkten Aggregator gesendet und das zurückgegebene Promise mit `signal.reason` rejected.
- Neue Option `abortGracePeriod` (Default 1000 ms) — Wartezeit vor der Eskalation zu `SIGKILL`.
- Zwei neue Fixture-Aggregatoren und ein umfangreicher Spec-Block (7 Tests), die die neuen Pfade abdecken.